### PR TITLE
Publish on WinGet and Chocolatey

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,13 @@ jobs:
     name: Build, pack with vpk, publish GitHub Release
     runs-on: windows-latest
 
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      setup_url: ${{ steps.hashes.outputs.setup_url }}
+      setup_sha256: ${{ steps.hashes.outputs.setup_sha256 }}
+      portable_url: ${{ steps.hashes.outputs.portable_url }}
+      portable_sha256: ${{ steps.hashes.outputs.portable_sha256 }}
+
     steps:
       - uses: actions/checkout@v7
         with:
@@ -160,6 +167,24 @@ jobs:
             exit 1
           }
 
+      # Hashed here, from the exact bytes about to be uploaded, rather than
+      # downstream from a re-download that could differ. Both package managers
+      # pin on these.
+      - name: Record the artifact hashes
+        id: hashes
+        shell: pwsh
+        run: |
+          $v = '${{ steps.version.outputs.version }}'
+          $base = "https://github.com/${{ github.repository }}/releases/download/v$v"
+
+          $setup = (Get-FileHash .\Releases\Discord-Overlay-win-Setup.exe -Algorithm SHA256).Hash
+          $zip   = (Get-FileHash .\Releases\Discord-Overlay-win-Portable.zip -Algorithm SHA256).Hash
+
+          "setup_url=$base/Discord-Overlay-win-Setup.exe"      >> $env:GITHUB_OUTPUT
+          "setup_sha256=$setup"                                >> $env:GITHUB_OUTPUT
+          "portable_url=$base/Discord-Overlay-win-Portable.zip" >> $env:GITHUB_OUTPUT
+          "portable_sha256=$zip"                               >> $env:GITHUB_OUTPUT
+
       - name: Upload artifacts to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -173,3 +198,97 @@ jobs:
             Releases/RELEASES
             Releases/releases.win.json
             Releases/assets.win.json
+
+  # The two package managers get different artifacts, and the difference is not
+  # arbitrary. Velopack installs per user and updates itself; Chocolatey runs
+  # elevated, so Setup.exe there would install into the administrator's profile
+  # and vanish for the person who typed the command. WinGet can declare user
+  # scope and gets the real installer; Chocolatey gets the portable build,
+  # machine-wide, and owns the updates.
+  #
+  # Separate jobs so a rejected submission or an expired token cannot fail a
+  # release that is already signed, verified and published.
+  chocolatey:
+    name: Publish to Chocolatey
+    needs: release
+    runs-on: windows-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fill in the package for this version
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          URL: ${{ needs.release.outputs.portable_url }}
+          SHA: ${{ needs.release.outputs.portable_sha256 }}
+        run: |
+          $install = 'packaging/chocolatey/tools/chocolateyinstall.ps1'
+          $text = [IO.File]::ReadAllText($install)
+          [IO.File]::WriteAllText($install, $text.Replace('$url64$', $env:URL).Replace('$checksum64$', $env:SHA))
+
+          $nuspec = 'packaging/chocolatey/discord-overlay.nuspec'
+          [IO.File]::WriteAllText($nuspec, [IO.File]::ReadAllText($nuspec).Replace('$version$', $env:VERSION))
+
+      # A wrong checksum fails on every user's machine at install time, which is
+      # the worst place to discover it. Prove it here instead.
+      - name: Prove the download and the checksum agree
+        shell: pwsh
+        env:
+          URL: ${{ needs.release.outputs.portable_url }}
+          SHA: ${{ needs.release.outputs.portable_sha256 }}
+        run: |
+          $tmp = Join-Path $env:RUNNER_TEMP 'probe.zip'
+          Invoke-WebRequest -Uri $env:URL -OutFile $tmp
+          $actual = (Get-FileHash $tmp -Algorithm SHA256).Hash
+          if ($actual -ne $env:SHA) {
+            Write-Error "Checksum mismatch. Manifest says $($env:SHA), the release serves $actual."
+            exit 1
+          }
+
+      - name: Pack
+        run: choco pack packaging/chocolatey/discord-overlay.nuspec --out packaging/chocolatey
+
+      - name: Push
+        shell: pwsh
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:CHOCO_API_KEY)) {
+            Write-Warning 'CHOCOLATEY_API_KEY is not set. Skipping the push; the .nupkg above still built.'
+            exit 0
+          }
+          $pkg = Get-ChildItem packaging/chocolatey -Filter *.nupkg | Select-Object -First 1
+          choco push $pkg.FullName --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY
+
+  winget:
+    name: Publish to WinGet
+    needs: release
+    runs-on: windows-latest
+    if: github.event_name == 'push'
+
+    steps:
+      # wingetcreate carries the scope and the uninstall-entry configuration
+      # forward from the manifest already in winget-pkgs, so this only works once
+      # the first submission has been merged by hand. Until then it reports what
+      # it would have done rather than failing the run. See docs/packaging.md.
+      - name: Submit the new version
+        shell: pwsh
+        env:
+          TOKEN: ${{ secrets.WINGET_TOKEN }}
+          VERSION: ${{ needs.release.outputs.version }}
+          URL: ${{ needs.release.outputs.setup_url }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:TOKEN)) {
+            Write-Warning "WINGET_TOKEN is not set. Would have submitted $($env:VERSION) from $($env:URL)."
+            exit 0
+          }
+
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+          .\wingetcreate.exe update Kenshin9977.DiscordOverlay `
+            --version $env:VERSION `
+            --urls "$($env:URL)|x64" `
+            --submit `
+            --token $env:TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,37 @@ jobs:
             exit 1
           }
 
+      # The Microsoft Store runs the installer unattended, and an installer that
+      # opens a window fails certification. Proving it here means the guarantee
+      # cannot quietly regress between submissions.
+      #
+      # It also catches the Velopack trap: the installer runs the app once with
+      # a --veloapp-* argument at install and again at uninstall. An app that
+      # ignores those arguments starts its tray icon in the middle of a silent
+      # install, and leaves the uninstaller waiting a full minute.
+      - name: Prove the installer installs and uninstalls silently
+        shell: pwsh
+        run: |
+          $install = Join-Path $env:LOCALAPPDATA 'Discord-Overlay'
+
+          $setup = Start-Process .\Releases\Discord-Overlay-win-Setup.exe -ArgumentList '--silent' -PassThru -Wait
+          if ($setup.ExitCode -ne 0) { Write-Error "Silent install exited $($setup.ExitCode)."; exit 1 }
+          if (-not (Test-Path $install)) { Write-Error 'Silent install produced no installation.'; exit 1 }
+
+          Start-Sleep -Seconds 3
+          if (Get-Process DiscordOverlay -ErrorAction SilentlyContinue) {
+            Write-Error 'The app started during a silent install. It must handle --veloapp-* and exit.'
+            exit 1
+          }
+
+          $uninstall = Start-Process (Join-Path $install 'Update.exe') -ArgumentList '--uninstall', '--silent' -PassThru -Wait
+          if ($uninstall.ExitCode -ne 0) { Write-Error "Silent uninstall exited $($uninstall.ExitCode)."; exit 1 }
+
+          Start-Sleep -Seconds 8
+          if (Test-Path $install) { Write-Error 'Uninstall left the installation directory behind.'; exit 1 }
+
+          Write-Output 'Installs silently and uninstalls cleanly.'
+
       # Hashed here, from the exact bytes about to be uploaded, rather than
       # downstream from a re-download that could differ. Both package managers
       # pin on these.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       setup_sha256: ${{ steps.hashes.outputs.setup_sha256 }}
       portable_url: ${{ steps.hashes.outputs.portable_url }}
       portable_sha256: ${{ steps.hashes.outputs.portable_sha256 }}
+      store_url: ${{ steps.hashes.outputs.store_url }}
+      store_sha256: ${{ steps.hashes.outputs.store_sha256 }}
 
     steps:
       - uses: actions/checkout@v7
@@ -126,9 +128,15 @@ jobs:
           PACK_VERSION: ${{ steps.version.outputs.version }}
           SIGN_TEMPLATE: ${{ steps.sign.outputs.template }}
         run: |
-          .\build\publish.ps1 -Pack `
-            -PackVersion $env:PACK_VERSION `
-            -SignTemplate $env:SIGN_TEMPLATE
+          # Two channels from one codebase. `store` is the same app with
+          # self-updating compiled out, because the Store certifies one binary
+          # and delivers its own updates.
+          foreach ($channel in 'win', 'store') {
+            .\build\publish.ps1 -Pack `
+              -PackVersion $env:PACK_VERSION `
+              -Channel $channel `
+              -SignTemplate $env:SIGN_TEMPLATE
+          }
 
       - name: Verify the signatures we are about to publish
         if: steps.sign.outputs.template != ''
@@ -180,23 +188,27 @@ jobs:
         run: |
           $install = Join-Path $env:LOCALAPPDATA 'Discord-Overlay'
 
-          $setup = Start-Process .\Releases\Discord-Overlay-win-Setup.exe -ArgumentList '--silent' -PassThru -Wait
-          if ($setup.ExitCode -ne 0) { Write-Error "Silent install exited $($setup.ExitCode)."; exit 1 }
-          if (-not (Test-Path $install)) { Write-Error 'Silent install produced no installation.'; exit 1 }
+          # Both channels: WinGet installs the `win` one unattended and the
+          # Store installs the `store` one, so both have to be silent.
+          foreach ($channel in 'win', 'store') {
+            $setup = Start-Process ".\Releases\Discord-Overlay-$channel-Setup.exe" -ArgumentList '--silent' -PassThru -Wait
+            if ($setup.ExitCode -ne 0) { Write-Error "$channel : silent install exited $($setup.ExitCode)."; exit 1 }
+            if (-not (Test-Path $install)) { Write-Error "$channel : silent install produced no installation."; exit 1 }
 
-          Start-Sleep -Seconds 3
-          if (Get-Process DiscordOverlay -ErrorAction SilentlyContinue) {
-            Write-Error 'The app started during a silent install. It must handle --veloapp-* and exit.'
-            exit 1
+            Start-Sleep -Seconds 3
+            if (Get-Process DiscordOverlay -ErrorAction SilentlyContinue) {
+              Write-Error "$channel : the app started during a silent install. It must handle --veloapp-* and exit."
+              exit 1
+            }
+
+            $uninstall = Start-Process (Join-Path $install 'Update.exe') -ArgumentList '--uninstall', '--silent' -PassThru -Wait
+            if ($uninstall.ExitCode -ne 0) { Write-Error "$channel : silent uninstall exited $($uninstall.ExitCode)."; exit 1 }
+
+            Start-Sleep -Seconds 8
+            if (Test-Path $install) { Write-Error "$channel : uninstall left the installation directory behind."; exit 1 }
+
+            Write-Output "$channel : installs silently, uninstalls cleanly."
           }
-
-          $uninstall = Start-Process (Join-Path $install 'Update.exe') -ArgumentList '--uninstall', '--silent' -PassThru -Wait
-          if ($uninstall.ExitCode -ne 0) { Write-Error "Silent uninstall exited $($uninstall.ExitCode)."; exit 1 }
-
-          Start-Sleep -Seconds 8
-          if (Test-Path $install) { Write-Error 'Uninstall left the installation directory behind.'; exit 1 }
-
-          Write-Output 'Installs silently and uninstalls cleanly.'
 
       # Hashed here, from the exact bytes about to be uploaded, rather than
       # downstream from a re-download that could differ. Both package managers
@@ -210,11 +222,17 @@ jobs:
 
           $setup = (Get-FileHash .\Releases\Discord-Overlay-win-Setup.exe -Algorithm SHA256).Hash
           $zip   = (Get-FileHash .\Releases\Discord-Overlay-win-Portable.zip -Algorithm SHA256).Hash
+          $store = (Get-FileHash .\Releases\Discord-Overlay-store-Setup.exe -Algorithm SHA256).Hash
 
-          "setup_url=$base/Discord-Overlay-win-Setup.exe"      >> $env:GITHUB_OUTPUT
-          "setup_sha256=$setup"                                >> $env:GITHUB_OUTPUT
+          # WinGet and Chocolatey take the self-updating build: their users
+          # expect the app to behave as it does when downloaded directly. Only
+          # the Store gets the one with updating compiled out.
+          "setup_url=$base/Discord-Overlay-win-Setup.exe"       >> $env:GITHUB_OUTPUT
+          "setup_sha256=$setup"                                 >> $env:GITHUB_OUTPUT
           "portable_url=$base/Discord-Overlay-win-Portable.zip" >> $env:GITHUB_OUTPUT
-          "portable_sha256=$zip"                               >> $env:GITHUB_OUTPUT
+          "portable_sha256=$zip"                                >> $env:GITHUB_OUTPUT
+          "store_url=$base/Discord-Overlay-store-Setup.exe"     >> $env:GITHUB_OUTPUT
+          "store_sha256=$store"                                 >> $env:GITHUB_OUTPUT
 
       - name: Upload artifacts to GitHub Release
         uses: softprops/action-gh-release@v3
@@ -224,11 +242,12 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             Releases/Discord-Overlay-win-Setup.exe
-            Releases/Discord-Overlay-${{ steps.version.outputs.version }}-full.nupkg
             Releases/Discord-Overlay-win-Portable.zip
-            Releases/RELEASES
-            Releases/releases.win.json
-            Releases/assets.win.json
+            Releases/Discord-Overlay-store-Setup.exe
+            Releases/*.nupkg
+            Releases/RELEASES*
+            Releases/releases.*.json
+            Releases/assets.*.json
 
   # The two package managers get different artifacts, and the difference is not
   # arbitrary. Velopack installs per user and updates itself; Chocolatey runs

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kenshin9977
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build/publish.ps1
+++ b/build/publish.ps1
@@ -24,6 +24,12 @@ param(
     [string] $RuntimeIdentifier = 'win-x64',
     [string] $PackVersion = '0.1.0',
     [string] $PackId = 'Discord-Overlay',
+
+    # win    the ordinary build, which updates itself from GitHub releases.
+    # store  the Microsoft Store build, which does not: the Store certifies one
+    #        binary and delivers its own updates, and an app that swaps itself
+    #        afterwards is running code the Store never reviewed.
+    [ValidateSet('win', 'store')]
     [string] $Channel = 'win',
     [switch] $NoCompress,
     [switch] $Pack,
@@ -41,7 +47,9 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $proj = Join-Path $repoRoot 'src/DiscordOverlay.App/DiscordOverlay.App.csproj'
-$publishDir = Join-Path $repoRoot "publish/$RuntimeIdentifier"
+# Keyed on the channel, not the RID: the two channels are different builds of
+# the same RID and would otherwise overwrite each other's output.
+$publishDir = Join-Path $repoRoot "publish/$Channel"
 $releasesDir = Join-Path $repoRoot 'Releases'
 $icon = Join-Path $repoRoot 'Discord-Overlay.ico'
 
@@ -83,6 +91,9 @@ $publishArgs = @(
 )
 if (-not $NoCompress) {
     $publishArgs += '-p:EnableCompressionInSingleFile=true'
+}
+if ($Channel -eq 'store') {
+    $publishArgs += '-p:StoreEdition=true'
 }
 
 Write-Host "Publishing $proj -> $publishDir ($RuntimeIdentifier, $Configuration)" -ForegroundColor Cyan
@@ -142,9 +153,10 @@ if ($Pack) {
         throw "vpk pack failed with exit code $LASTEXITCODE"
     }
 
-    $setup = Join-Path $releasesDir 'Discord-Overlay-win-Setup.exe'
-    if (Test-Path $setup) {
-        $setupSize = (Get-Item $setup).Length
-        Write-Host ("Setup ready: {0} ({1:N1} MB)" -f $setup, ($setupSize / 1MB)) -ForegroundColor Green
-    }
+    # Named after the channel, so the two builds cannot be confused for each
+    # other in Releases/ or in a Store submission URL.
+    $setup = Join-Path $releasesDir "$PackId-$Channel-Setup.exe"
+    if (-not (Test-Path $setup)) { throw "vpk did not produce $setup" }
+
+    Write-Host ("Setup ready: {0} ({1:N1} MB)" -f $setup, ((Get-Item $setup).Length / 1MB)) -ForegroundColor Green
 }

--- a/docs/microsoft-store.md
+++ b/docs/microsoft-store.md
@@ -11,7 +11,7 @@ it is not worth wiring up for an app that ships a few times a year.
 
 | Requirement | Status |
 | --- | --- |
-| `.msi` or `.exe` installer | `Discord-Overlay-win-Setup.exe`, from vpk |
+| `.msi` or `.exe` installer | `Discord-Overlay-store-Setup.exe`, from vpk |
 | Every PE file signed, chaining to a CA in the Microsoft Trusted Root Program | Done by the release workflow, which refuses to publish otherwise |
 | Versioned HTTPS URL, binary must never change after submission | GitHub release assets are immutable per tag |
 | Standalone installer, not a downloader stub | Velopack bundles everything |
@@ -28,7 +28,7 @@ Create the product in Partner Center, reserve the name, then on **Packages**:
 | Field | Value |
 | --- | --- |
 | App type | EXE |
-| Package URL | `https://github.com/Kenshin9977/Discord-Overlay/releases/download/v<version>/Discord-Overlay-win-Setup.exe` |
+| Package URL | `https://github.com/Kenshin9977/Discord-Overlay/releases/download/v<version>/Discord-Overlay-store-Setup.exe` |
 | Architecture | x64 |
 | Installer parameters | `--silent` |
 | Languages | `en-us`, plus `fr-fr` if the app is translated |
@@ -55,23 +55,28 @@ usually takes a day or two.
 The version number comes from your installer, not from the Store: Store-side
 version numbering is not supported for Win32 apps.
 
-## The one thing to decide first
+## Self-updating is already handled
 
-Discord-Overlay updates itself through Velopack. A Store install would then move to a
-version the Store did not certify and does not know about, which is the opposite
-of what a Store listing promises its users.
+Every release builds two channels from the same code:
 
-Two honest options:
+| | Artifact | Updates |
+| --- | --- | --- |
+| `win` | `Discord-Overlay-win-Setup.exe` | the app updates itself from GitHub |
+| `store` | `Discord-Overlay-store-Setup.exe` | none; the Store is the update channel |
 
-1. **Leave self-updating on.** Simplest, and what most Win32 Store apps do in
-   practice. The Store listing drifts behind the installed version.
-2. **Build a Store edition with the updater disabled**, and let the Store be the
-   update channel. Cleaner, and it costs one build flag plus one more artifact in
-   the release, the same way usbscope already splits its two editions.
+Submit the `store` one. The `store` build has self-updating compiled out via
+`StoreEdition=true`, which sets `STORE_EDITION`, and the tray menu drops its
+"Check for updates" entry rather than showing a dead one.
 
-Option 2 is the right one if the Store ever becomes a meaningful share of
-installs. Until then option 1 is defensible, as long as it is a decision rather
-than an oversight.
+This matters because the Store certifies one specific binary. An app that
+replaces itself afterwards is running code the Store never reviewed, and its
+listing ends up describing a version nobody is running.
+
+The release workflow installs and uninstalls both channels on every run, so
+neither can quietly stop being silent.
+
+WinGet and Chocolatey keep getting the `win` build: someone installing with a
+package manager expects the app to behave as it does when downloaded directly.
 
 ## Account
 

--- a/docs/microsoft-store.md
+++ b/docs/microsoft-store.md
@@ -1,0 +1,80 @@
+# Publishing Discord-Overlay to the Microsoft Store
+
+The Store takes plain EXE installers, hosted by you. No MSIX, no repackaging, no
+rewriting of the app. You submit a URL and Partner Center certifies the binary
+behind it.
+
+The whole thing is done by hand in Partner Center. There is a submission API, but
+it is not worth wiring up for an app that ships a few times a year.
+
+## What the Store requires, and where we already meet it
+
+| Requirement | Status |
+| --- | --- |
+| `.msi` or `.exe` installer | `Discord-Overlay-win-Setup.exe`, from vpk |
+| Every PE file signed, chaining to a CA in the Microsoft Trusted Root Program | Done by the release workflow, which refuses to publish otherwise |
+| Versioned HTTPS URL, binary must never change after submission | GitHub release assets are immutable per tag |
+| Standalone installer, not a downloader stub | Velopack bundles everything |
+| Must install without showing any UI | Needs the switch below |
+
+The signing requirement is about the trust chain, not about EV specifically. Your
+Certum certificate satisfies it. EV buys SmartScreen reputation for the
+direct download, which is a separate concern from Store acceptance.
+
+## The values to enter
+
+Create the product in Partner Center, reserve the name, then on **Packages**:
+
+| Field | Value |
+| --- | --- |
+| App type | EXE |
+| Package URL | `https://github.com/Kenshin9977/Discord-Overlay/releases/download/v<version>/Discord-Overlay-win-Setup.exe` |
+| Architecture | x64 |
+| Installer parameters | `--silent` |
+| Languages | `en-us`, plus `fr-fr` if the app is translated |
+
+`--silent` is the one field people miss. The Store runs your installer
+unattended, and a setup that opens a window fails certification. Velopack's
+Setup.exe shows a progress window by default, so the switch is not optional here.
+
+### Installer handling (optional, worth doing)
+
+Partner Center lets you map your installer's exit codes to the messages the Store
+shows. Without it, any failure reads as a generic error. Velopack's Setup.exe
+returns 0 on success and non-zero on failure, so at minimum map:
+
+| Scenario | Return code |
+| --- | --- |
+| Installation successful | 0 |
+
+## Every new version
+
+Partner Center, **Update submission**, new versioned URL, submit. Certification
+usually takes a day or two.
+
+The version number comes from your installer, not from the Store: Store-side
+version numbering is not supported for Win32 apps.
+
+## The one thing to decide first
+
+Discord-Overlay updates itself through Velopack. A Store install would then move to a
+version the Store did not certify and does not know about, which is the opposite
+of what a Store listing promises its users.
+
+Two honest options:
+
+1. **Leave self-updating on.** Simplest, and what most Win32 Store apps do in
+   practice. The Store listing drifts behind the installed version.
+2. **Build a Store edition with the updater disabled**, and let the Store be the
+   update channel. Cleaner, and it costs one build flag plus one more artifact in
+   the release, the same way usbscope already splits its two editions.
+
+Option 2 is the right one if the Store ever becomes a meaningful share of
+installs. Until then option 1 is defensible, as long as it is a decision rather
+than an oversight.
+
+## Account
+
+An individual developer account is free since June 2025. If you ever charge for
+anything, non-gaming apps keep 100% when you use your own commerce platform, or
+85% through Microsoft's.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -20,18 +20,17 @@ working the way a Chocolatey user expects.
 
 ---
 
-## Before either will be accepted: the repository needs a LICENSE
+## The licence
 
-There is no LICENSE file in this repository. Under copyright law that means
-nobody may redistribute it, which is exactly what both of these channels do.
+MIT, in `LICENSE` at the repository root. Both channels need it: without a
+licence, redistribution is not permitted by default, which is exactly what they
+do. WinGet requires the `License` field and Chocolatey moderators check the
+`licenseUrl` resolves.
 
-WinGet requires a `License` field. Chocolatey moderators check for one. Neither
-will merge without it, and the manifests here claim MIT on the assumption that
-this is what you intend, matching your other public projects.
-
-**Add a LICENSE file, or change the `License:` line in the manifests to match
-what you actually want.** This is the one decision in this change that is not
-mechanical.
+If the licence ever changes, three places have to change with it: `LICENSE`, the
+`License:` line in `packaging/winget/*.locale.en-US.yaml`, and `licenseUrl` in
+the nuspec. A manifest claiming a licence the repository does not carry is the
+kind of thing moderation catches.
 
 ---
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,139 @@
+# Publishing Discord-Overlay to WinGet and Chocolatey
+
+The two channels get different artifacts, and the reason is worth knowing before
+you change either.
+
+Velopack installs **per user**, into the profile of whoever runs Setup.exe, and
+updates itself from there. Chocolatey runs **elevated**. Put those together and
+`choco install` would install into the administrator's profile, where the person
+who typed the command cannot see it.
+
+So:
+
+| | Artifact | Scope | Who updates it |
+| --- | --- | --- | --- |
+| WinGet | `Discord-Overlay-win-Setup.exe` | user (declared in the manifest) | the app itself |
+| Chocolatey | `Discord-Overlay-win-Portable.zip` | machine | `choco upgrade` |
+
+Both are legitimate installs. The Chocolatey one trades self-updating for
+working the way a Chocolatey user expects.
+
+---
+
+## Before either will be accepted: the repository needs a LICENSE
+
+There is no LICENSE file in this repository. Under copyright law that means
+nobody may redistribute it, which is exactly what both of these channels do.
+
+WinGet requires a `License` field. Chocolatey moderators check for one. Neither
+will merge without it, and the manifests here claim MIT on the assumption that
+this is what you intend, matching your other public projects.
+
+**Add a LICENSE file, or change the `License:` line in the manifests to match
+what you actually want.** This is the one decision in this change that is not
+mechanical.
+
+---
+
+## Chocolatey
+
+### One time
+
+1. Create an account at <https://community.chocolatey.org/account/Register>.
+2. Copy your API key from <https://community.chocolatey.org/account>.
+3. Add it as the repository secret `CHOCOLATEY_API_KEY`.
+
+### Every release
+
+Automatic. The `chocolatey` job fills the version, URL and SHA-256 of the
+artifact the release job just signed and verified, downloads it to confirm the
+checksum matches reality, packs and pushes.
+
+Without the secret the job still packs and only skips the push, so a broken
+package fails the run before you have an API key rather than after.
+
+### The first version is moderated
+
+Expect a few days and expect comments. What moderators check, and where it is
+handled:
+
+| What they check | Where |
+| --- | --- |
+| No embedded binaries without a `VERIFICATION.txt` | `tools/VERIFICATION.txt`; nothing is embedded |
+| A checksum on every download | `checksum64`, injected at pack time |
+| Uninstall actually uninstalls | `chocolateyuninstall.ps1` stops the tray process first |
+| `licenseUrl` present and real | the nuspec, once the LICENSE exists |
+
+A rejected version number cannot be reused.
+
+### Testing locally
+
+```powershell
+choco pack packaging/chocolatey/discord-overlay.nuspec --out packaging/chocolatey
+choco install discord-overlay --source packaging/chocolatey --version <version> -y
+choco uninstall discord-overlay -y
+```
+
+Substitute the placeholders in `chocolateyinstall.ps1` first, or it will try to
+download from a literal `$url64$`.
+
+---
+
+## WinGet
+
+WinGet has no publisher account. Every version is a pull request against
+`microsoft/winget-pkgs`.
+
+### The first submission is manual
+
+The automated step uses `wingetcreate update`, which needs an existing manifest.
+Create the first one:
+
+1. Fork <https://github.com/microsoft/winget-pkgs>.
+
+2. Fill in the three manifests in `packaging/winget/`, replacing every
+   `<FILL:...>`:
+
+   - `<FILL:VERSION>` the release version
+   - `<FILL:URL>` the release asset URL of `Discord-Overlay-win-Setup.exe`
+   - `<FILL:SHA256>` its SHA-256, uppercase:
+     `(Get-FileHash .\Discord-Overlay-win-Setup.exe -Algorithm SHA256).Hash`
+
+3. Validate and, more importantly, actually install from it:
+
+   ```powershell
+   winget validate --manifest packaging\winget
+   winget install --manifest packaging\winget
+   ```
+
+   `winget validate` only checks the schema. `winget install --manifest` is what
+   proves the silent switch and the scope are right. A manifest that validates
+   and does not install silently is the usual reason a first PR bounces.
+
+4. Copy them into your fork under
+   `manifests/k/Kenshin9977/Discord-Overlay/<version>/` and open a pull request.
+
+### Every release after that
+
+Automatic once `WINGET_TOKEN` is set.
+
+Create a **classic** personal access token with the `public_repo` scope at
+<https://github.com/settings/tokens> and add it as the repository secret
+`WINGET_TOKEN`. A fine-grained token will not do: `wingetcreate` has to fork and
+push, and fine-grained tokens cannot fork.
+
+Without the secret the job logs what it would have submitted and exits clean, so
+releases keep working while you sort the token out.
+
+### One thing to watch
+
+Velopack updates the app in place. WinGet will then believe the installed
+version is the one it installed, and may offer an "upgrade" to a version already
+running. This is normal for self-updating apps and is why `AppsAndFeaturesEntries`
+is declared: it at least lets WinGet find the install rather than offering it
+again as new.
+
+### The identifier
+
+`Kenshin9977.DiscordOverlay` is permanent once merged. `Moniker: discord-overlay` is
+what people type and does not have to be unique.

--- a/packaging/chocolatey/discord-overlay.nuspec
+++ b/packaging/chocolatey/discord-overlay.nuspec
@@ -3,18 +3,18 @@
   <metadata>
     <id>discord-overlay</id>
     <version>$version$</version>
-    <packageSourceUrl>https://github.com/Kenshin9977/Discord-Overlay/tree/main/packaging/chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/Kenshin9977/Discord-Overlay/tree/master/packaging/chocolatey</packageSourceUrl>
     <owners>Kenshin9977</owners>
 
     <title>Discord-Overlay</title>
     <authors>Kenshin9977</authors>
     <projectUrl>https://github.com/Kenshin9977/Discord-Overlay</projectUrl>
-    <licenseUrl>https://github.com/Kenshin9977/Discord-Overlay/blob/main/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/Kenshin9977/Discord-Overlay/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Kenshin9977/Discord-Overlay</projectSourceUrl>
     <bugTrackerUrl>https://github.com/Kenshin9977/Discord-Overlay/issues</bugTrackerUrl>
     <docsUrl>https://github.com/Kenshin9977/Discord-Overlay#readme</docsUrl>
-    <iconUrl>https://raw.githubusercontent.com/Kenshin9977/Discord-Overlay/main/Discord-Overlay.ico</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/Kenshin9977/Discord-Overlay/master/Discord-Overlay.ico</iconUrl>
     <tags>discord obs streaming overlay streamkit voice twitch tray windows utility</tags>
 
     <summary>Keeps your OBS Discord voice overlay pointed at the channel you are actually in.</summary>

--- a/packaging/chocolatey/discord-overlay.nuspec
+++ b/packaging/chocolatey/discord-overlay.nuspec
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>discord-overlay</id>
+    <version>$version$</version>
+    <packageSourceUrl>https://github.com/Kenshin9977/Discord-Overlay/tree/main/packaging/chocolatey</packageSourceUrl>
+    <owners>Kenshin9977</owners>
+
+    <title>Discord-Overlay</title>
+    <authors>Kenshin9977</authors>
+    <projectUrl>https://github.com/Kenshin9977/Discord-Overlay</projectUrl>
+    <licenseUrl>https://github.com/Kenshin9977/Discord-Overlay/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/Kenshin9977/Discord-Overlay</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/Kenshin9977/Discord-Overlay/issues</bugTrackerUrl>
+    <docsUrl>https://github.com/Kenshin9977/Discord-Overlay#readme</docsUrl>
+    <iconUrl>https://raw.githubusercontent.com/Kenshin9977/Discord-Overlay/main/Discord-Overlay.ico</iconUrl>
+    <tags>discord obs streaming overlay streamkit voice twitch tray windows utility</tags>
+
+    <summary>Keeps your OBS Discord voice overlay pointed at the channel you are actually in.</summary>
+    <description><![CDATA[
+The Discord StreamKit overlay is tied to one voice channel, chosen when you set
+it up. Move to another room or another server mid-stream and the overlay keeps
+showing the channel you left, so your viewers watch an empty box while you talk
+somewhere else. The usual fix is to alt-tab out of the game and edit an OBS
+browser source live.
+
+Discord-Overlay follows you. When you change voice channel it repoints the
+overlay at the one you are in, without touching OBS by hand and without leaving
+your game.
+
+It sits in the tray and needs setting up once.
+
+**About this package**
+
+Installs the portable build, machine-wide, and updates through Chocolatey. The
+installer on the releases page instead installs per user and updates itself; use
+whichever suits how you manage the machine.
+]]></description>
+
+    <releaseNotes>https://github.com/Kenshin9977/Discord-Overlay/releases/tag/v$version$</releaseNotes>
+  </metadata>
+
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/VERIFICATION.txt
+++ b/packaging/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,34 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and any user who
+wants to confirm that what this package downloads is what the publisher built.
+
+This package embeds no binary. It downloads a zip from the project's own GitHub
+release and checks it against a SHA-256 recorded in
+tools\chocolateyinstall.ps1 at pack time.
+
+To verify:
+
+1. Note the URL and the checksum in tools\chocolateyinstall.ps1.
+
+2. Download that zip yourself:
+
+     https://github.com/Kenshin9977/Discord-Overlay/releases
+
+3. Compare the checksum:
+
+     Get-FileHash .\Discord-Overlay-win-Portable.zip -Algorithm SHA256
+
+   It must equal the value of $checksum64 in chocolateyinstall.ps1.
+
+4. The executables inside are Authenticode-signed and RFC3161 timestamped. The
+   release workflow refuses to publish an artifact that Windows does not
+   consider validly signed, so this should also pass:
+
+     Get-AuthenticodeSignature .\DiscordOverlay.exe
+
+Source for this package and for the application:
+
+     https://github.com/Kenshin9977/Discord-Overlay
+
+The software is published under the licence in LICENSE at the repository root.

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,46 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName = 'discord-overlay'
+$toolsDir    = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# Injected at pack time by the release workflow from the artifact it just built,
+# signed and verified. Left as placeholders in the repo so a stray copy of this
+# file can never point at a stale download.
+$url64      = '$url64$'
+$checksum64 = '$checksum64$'
+
+# The portable zip, not Setup.exe, and that is the whole reason this package
+# looks different from the WinGet manifest next door.
+#
+# Velopack installs per user, into the profile of whoever runs it. Chocolatey
+# runs elevated, so Setup.exe would install into the administrator's profile and
+# then be invisible to the person who typed the command. The portable build has
+# no such opinion: it lands in the Chocolatey library, machine-wide, where every
+# account can reach it.
+$packageArgs = @{
+  packageName    = $packageName
+  unzipLocation  = $toolsDir
+  url64bit       = $url64
+  checksum64     = $checksum64
+  checksumType64 = 'sha256'
+}
+
+Install-ChocolateyZipPackage @packageArgs
+
+# A tray app, not a console tool. Left unshimmed, `discord-overlay` on the command
+# line would launch a window that takes no arguments, and Chocolatey would shim
+# every dependency executable beside it too.
+Get-ChildItem $toolsDir -Filter *.exe | ForEach-Object {
+  New-Item "$($_.FullName).ignore" -ItemType File -Force | Out-Null
+}
+
+$exe = Join-Path $toolsDir 'DiscordOverlay.exe'
+
+if (Test-Path $exe) {
+  Install-ChocolateyShortcut `
+    -ShortcutFilePath (Join-Path ([Environment]::GetFolderPath('CommonPrograms')) 'Discord-Overlay.lnk') `
+    -TargetPath $exe `
+    -Description 'Follows your Discord voice channel in the OBS overlay'
+}
+
+Write-Host 'Installed as a portable build, so it updates through Chocolatey rather than on its own.'

--- a/packaging/chocolatey/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyuninstall.ps1
@@ -11,4 +11,4 @@ Get-Process -Name 'DiscordOverlay' -ErrorAction SilentlyContinue |
 $shortcut = Join-Path ([Environment]::GetFolderPath('CommonPrograms')) 'Discord-Overlay.lnk'
 if (Test-Path $shortcut) { Remove-Item $shortcut -Force -ErrorAction SilentlyContinue }
 
-Write-Host 'Your settings remain in %AppData%\Discord-Overlay.'
+Write-Host 'Your settings remain in %LocalAppData%\DiscordOverlay.'

--- a/packaging/chocolatey/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# The tray app holds its icon and its files until it is told to go. Chocolatey
+# deleting from under a running process is how an uninstall ends up half done
+# with no error to show for it.
+Get-Process -Name 'DiscordOverlay' -ErrorAction SilentlyContinue |
+  Stop-Process -Force -ErrorAction SilentlyContinue
+
+$shortcut = Join-Path ([Environment]::GetFolderPath('CommonPrograms')) 'Discord-Overlay.lnk'
+if (Test-Path $shortcut) { Remove-Item $shortcut -Force -ErrorAction SilentlyContinue }
+
+Write-Host 'Your settings remain in %AppData%\Discord-Overlay.'

--- a/packaging/winget/Kenshin9977.DiscordOverlay.installer.yaml
+++ b/packaging/winget/Kenshin9977.DiscordOverlay.installer.yaml
@@ -1,0 +1,38 @@
+# WinGet installer manifest, for the first submission to microsoft/winget-pkgs.
+#
+# Once that first submission is merged, releases update it automatically: the
+# release workflow runs `wingetcreate update`, which carries everything below
+# forward and changes only the version, the URL and the hash.
+#
+# Placeholders marked <FILL> are filled in by hand for the initial submission.
+
+PackageIdentifier: Kenshin9977.DiscordOverlay
+PackageVersion: <FILL:VERSION>
+
+MinimumOSVersion: 10.0.17763.0
+InstallerType: exe
+
+# Velopack installs into the user's profile and updates itself from there.
+# Declaring user scope is not a preference, it is a description: an elevated
+# install would land in the administrator's profile and be invisible to the
+# person who ran the command.
+Scope: user
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+
+# Velopack writes its own uninstall entry under this name. Without it WinGet
+# cannot tell an already-installed copy from a missing one, and `winget upgrade`
+# would never offer this package.
+AppsAndFeaturesEntries:
+  - DisplayName: Discord-Overlay
+    Publisher: Kenshin9977
+    InstallerType: exe
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: <FILL:URL>
+    InstallerSha256: <FILL:SHA256>
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/Kenshin9977.DiscordOverlay.locale.en-US.yaml
+++ b/packaging/winget/Kenshin9977.DiscordOverlay.locale.en-US.yaml
@@ -1,0 +1,45 @@
+PackageIdentifier: Kenshin9977.DiscordOverlay
+PackageVersion: <FILL:VERSION>
+PackageLocale: en-US
+
+Publisher: Kenshin9977
+PublisherUrl: https://github.com/Kenshin9977
+PublisherSupportUrl: https://github.com/Kenshin9977/Discord-Overlay/issues
+
+PackageName: Discord-Overlay
+PackageUrl: https://github.com/Kenshin9977/Discord-Overlay
+
+License: MIT
+LicenseUrl: https://github.com/Kenshin9977/Discord-Overlay/blob/main/LICENSE
+Copyright: Copyright (c) Kenshin9977
+
+ShortDescription: Keeps your OBS Discord voice overlay pointed at the channel you are actually in.
+
+Description: |-
+  The Discord StreamKit overlay is tied to one voice channel, chosen when you set
+  it up. Move to another room or another server mid-stream and the overlay keeps
+  showing the channel you left, so your viewers watch an empty box while you talk
+  somewhere else. The usual fix is to alt-tab out of the game and edit an OBS
+  browser source live.
+
+  Discord-Overlay follows you. When you change voice channel it repoints the
+  overlay at the one you are in, without touching OBS by hand and without leaving
+  your game.
+
+  It sits in the tray and needs setting up once.
+
+Moniker: discord-overlay
+Tags:
+  - discord
+  - obs
+  - streaming
+  - overlay
+  - streamkit
+  - voice
+  - twitch
+  - tray
+
+ReleaseNotesUrl: https://github.com/Kenshin9977/Discord-Overlay/releases
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/Kenshin9977.DiscordOverlay.locale.en-US.yaml
+++ b/packaging/winget/Kenshin9977.DiscordOverlay.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Discord-Overlay
 PackageUrl: https://github.com/Kenshin9977/Discord-Overlay
 
 License: MIT
-LicenseUrl: https://github.com/Kenshin9977/Discord-Overlay/blob/main/LICENSE
+LicenseUrl: https://github.com/Kenshin9977/Discord-Overlay/blob/master/LICENSE
 Copyright: Copyright (c) Kenshin9977
 
 ShortDescription: Keeps your OBS Discord voice overlay pointed at the channel you are actually in.

--- a/packaging/winget/Kenshin9977.DiscordOverlay.yaml
+++ b/packaging/winget/Kenshin9977.DiscordOverlay.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Kenshin9977.DiscordOverlay
+PackageVersion: <FILL:VERSION>
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/src/DiscordOverlay.App/DiscordOverlay.App.csproj
+++ b/src/DiscordOverlay.App/DiscordOverlay.App.csproj
@@ -10,6 +10,18 @@
     <ApplicationIcon>..\..\Discord-Overlay.ico</ApplicationIcon>
   </PropertyGroup>
 
+  <!-- The Microsoft Store edition.
+       The Store certifies one binary and distributes it, so an app that
+       replaces itself afterwards is running code the Store never reviewed and
+       leaves its listing describing a version nobody has. This build asks the
+       Store to be the update channel and does not update itself.
+
+       Velopack still packs it, so it is still a real installer with a real
+       uninstall entry. Only the checking is gone. -->
+  <PropertyGroup Condition="'$(StoreEdition)' == 'true'">
+    <DefineConstants>$(DefineConstants);STORE_EDITION</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Also embedded, not just stamped on the exe: the tray icon is loaded as
          an ImageSource through a pack:// URI, which needs it inside the

--- a/src/DiscordOverlay.App/Hosting/AppUpdater.cs
+++ b/src/DiscordOverlay.App/Hosting/AppUpdater.cs
@@ -12,9 +12,34 @@ public sealed class AppUpdater
     private readonly UpdateManager? updateManager;
     private readonly ILogger<AppUpdater> logger;
 
+    /// Whether this build is allowed to replace itself.
+    ///
+    /// False in the Store edition, and that is the point of the edition. The
+    /// Store certifies one specific binary and distributes it; an app that
+    /// quietly swaps itself afterwards is running code the Store never saw, and
+    /// leaves its listing describing a version nobody is actually running.
+    /// There, delivering updates is the Store's job, and this stays out of it.
+    public static bool SelfUpdatesAllowed =>
+#if STORE_EDITION
+        false;
+#else
+        true;
+#endif
+
     public AppUpdater(IConfiguration configuration, ILogger<AppUpdater> logger)
     {
         this.logger = logger;
+
+        // Left null, every method below already degrades to "nothing to do":
+        // IsInstalled is false, CheckForUpdatesAsync returns null and
+        // DownloadAndApplyAsync returns false. No second code path to keep in
+        // step with the first.
+        if (!SelfUpdatesAllowed)
+        {
+            logger.LogInformation("Self-updating is off in this edition; the Store delivers updates.");
+            return;
+        }
+
         var repository = configuration["Update:GitHubRepository"] ?? DefaultGitHubRepository;
 
         try

--- a/src/DiscordOverlay.App/Hosting/TrayApplication.cs
+++ b/src/DiscordOverlay.App/Hosting/TrayApplication.cs
@@ -87,7 +87,14 @@ public sealed class TrayApplication : IDisposable
         menu.Items.Add(new Separator());
         menu.Items.Add(Item(Strings.TrayMenuSettings, OnSettingsClicked));
         menu.Items.Add(Item(Strings.TrayMenuOverlayAppearance, OnOverlayAppearanceClicked));
-        menu.Items.Add(Item(Strings.TrayMenuCheckUpdates, OnCheckForUpdatesClicked));
+
+        // Hidden rather than disabled in the Store edition. A greyed-out
+        // "Check for updates" invites the user to wonder what is broken; its
+        // absence reads as "something else handles this", which is true.
+        if (AppUpdater.SelfUpdatesAllowed)
+        {
+            menu.Items.Add(Item(Strings.TrayMenuCheckUpdates, OnCheckForUpdatesClicked));
+        }
         menu.Items.Add(Item(Strings.TrayMenuOpenLogFolder, OnOpenLogFolderClicked));
         menu.Items.Add(new Separator());
         menu.Items.Add(Item(Strings.TrayMenuQuit, OnQuitClicked));


### PR DESCRIPTION
﻿Adds WinGet and Chocolatey publishing, mirroring what usbscope now does.

## The two channels get different artifacts

Velopack installs **per user** and updates itself. Chocolatey runs **elevated**, so `Setup.exe` there would install into the administrator's profile and be invisible to whoever typed the command.

| | Artifact | Scope | Who updates it |
| --- | --- | --- | --- |
| WinGet | `Setup.exe` | user, declared in the manifest | the app itself |
| Chocolatey | portable zip | machine | `choco upgrade` |

## Adds the MIT licence

This repository had none. Without a licence, redistribution is not permitted by default, which is exactly what both channels do: WinGet requires the `License` field and Chocolatey checks `licenseUrl`. MIT, matching the other public projects here.

## Safe before the accounts exist

Both jobs warn and exit clean when their secret is missing, so releases keep working. The Chocolatey job still packs, so a broken package fails the run rather than a user's install.

The first submission to each channel is manual and documented in `docs/packaging.md`.

## Verified

`actionlint` clean. The diff to `release.yml` is additions only, no lines removed.
