### PR TITLE
fix(streamkit): BackgroundOpacity as a 0-1 fraction, add StreamerAvatarFirst

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -174,11 +174,14 @@ l'écrit ; vous pouvez l'éditer à la main si vous voulez). Schéma :
     "Logo": "white",
     "TextColor": "#ffffff",
     "TextSize": 14,
+    "TextOutlineColor": "#000000",
+    "TextOutlineSize": 0,
     "BackgroundColor": "#1e2124",
     "BackgroundOpacity": 0,
     "LimitSpeaking": false,
     "SmallAvatars": false,
-    "HideNames": false
+    "HideNames": false,
+    "StreamerAvatarFirst": false
   },
   "Update": {
     "GitHubRepository": "https://github.com/Kenshin9977/Discord-Overlay"
@@ -190,6 +193,23 @@ Les changements d'hôte, de port, de mot de passe et de nom de Browser Source
 prennent effet après un redémarrage de l'app, car la connexion WebSocket OBS
 n'est établie qu'une fois au démarrage. Les options de l'overlay StreamKit, elles,
 sont prises en compte à chaud.
+
+Deux options StreamKit méritent une précision :
+
+- **`BackgroundOpacity`** est une fraction de `0` (transparent) à `1` (opaque)
+  — l'échelle qu'utilise le `bg_opacity` de StreamKit lui-même. Les décimales
+  s'écrivent avec un point : `0.75`. Une valeur supérieure à 1 est relue comme
+  l'ancien pourcentage 0-100, pour qu'un `settings.json` écrit par une version
+  précédente garde le fond qu'il avait.
+- **`StreamerAvatarFirst`** épingle votre propre profil en haut de la pile
+  vocale au lieu de le trier alphabétiquement avec les autres. C'est le
+  « Show My Avatar First » de StreamKit.
+
+Le fichier est prévu pour être édité à la main : les nombres entre guillemets
+(`"0.75"`), les commentaires `//` et les virgules finales sont acceptés. Si une
+édition le rend malgré tout illisible, l'application repart sur les valeurs par
+défaut et conserve votre version à côté sous le nom `settings.invalid.json`
+plutôt que de l'écraser.
 
 ## Dépannage
 

--- a/README.md
+++ b/README.md
@@ -167,11 +167,14 @@ Schema:
     "Logo": "white",
     "TextColor": "#ffffff",
     "TextSize": 14,
+    "TextOutlineColor": "#000000",
+    "TextOutlineSize": 0,
     "BackgroundColor": "#1e2124",
     "BackgroundOpacity": 0,
     "LimitSpeaking": false,
     "SmallAvatars": false,
-    "HideNames": false
+    "HideNames": false,
+    "StreamerAvatarFirst": false
   },
   "Update": {
     "GitHubRepository": "https://github.com/Kenshin9977/Discord-Overlay"
@@ -182,6 +185,21 @@ Schema:
 Host, port, password and Browser Source name changes take effect after an
 app restart since the OBS WebSocket connection is established once at
 startup. StreamKit overlay options pick up live.
+
+A few of the StreamKit options are worth spelling out:
+
+- **`BackgroundOpacity`** is a fraction from `0` (transparent) to `1` (opaque)
+  — the scale StreamKit's own `bg_opacity` uses. Decimals use a dot: `0.75`.
+  A value above 1 is read as the old 0-100 percentage, so a `settings.json`
+  written by an earlier version keeps the background it had.
+- **`StreamerAvatarFirst`** pins your own profile to the top of the voice
+  stack instead of sorting it in alphabetically. It is StreamKit's "Show My
+  Avatar First".
+
+The file is meant to be hand-editable, so quoted numbers (`"0.75"`), `//`
+comments and trailing commas are all accepted. If an edit does leave it
+unparseable, the app falls back to defaults and keeps your version as
+`settings.invalid.json` next to it rather than overwriting it.
 
 ## Troubleshooting
 

--- a/src/DiscordOverlay.Core/AppConfig.cs
+++ b/src/DiscordOverlay.Core/AppConfig.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using DiscordOverlay.Core.Discord;
 using DiscordOverlay.Core.Streaming;
 
@@ -23,6 +24,15 @@ public static class AppConfigStore
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
+
+        // This file is documented as hand-editable, so read it the way a person
+        // writes one: a quoted number ("0.75"), a trailing comma, a // note.
+        // Rejecting those costs the user every other setting in the file, since
+        // a parse failure here falls back to defaults and the next save writes
+        // them over the top.
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
     };
 
     public static async Task<AppConfig> LoadAsync(string? path = null, CancellationToken cancellationToken = default)
@@ -43,6 +53,10 @@ public static class AppConfigStore
         }
         catch (JsonException)
         {
+            // Defaults keep the app running, but the next save would overwrite
+            // the file with them. Keep the user's version so a typo costs a
+            // rename, not the whole configuration.
+            TryPreserveUnreadableFile(path);
             return new AppConfig();
         }
     }
@@ -62,5 +76,24 @@ public static class AppConfigStore
         var json = JsonSerializer.Serialize(config, JsonOptions);
         await File.WriteAllTextAsync(temp, json, cancellationToken).ConfigureAwait(false);
         File.Move(temp, path, overwrite: true);
+    }
+
+    /// <summary>
+    /// Copy a settings file we could not parse next to itself, so its contents
+    /// survive being replaced by defaults. Best-effort by design: failing to
+    /// take the backup must not stop the app from starting.
+    /// </summary>
+    private static void TryPreserveUnreadableFile(string path)
+    {
+        try
+        {
+            File.Copy(path, Path.ChangeExtension(path, ".invalid.json"), overwrite: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 }

--- a/src/DiscordOverlay.Core/Streaming/StreamKitOverlayOptions.cs
+++ b/src/DiscordOverlay.Core/Streaming/StreamKitOverlayOptions.cs
@@ -18,11 +18,29 @@ public sealed class StreamKitOverlayOptions
 
     public string BackgroundColor { get; set; } = "#1e2124";
 
-    public int BackgroundOpacity { get; set; } = 0;
+    /// <summary>
+    /// Background opacity as a fraction: <c>0</c> fully transparent, <c>1</c>
+    /// fully opaque, decimals allowed (<c>0.75</c>). This is the same scale
+    /// StreamKit's own <c>bg_opacity</c> uses, so what you write here is what
+    /// the overlay gets.
+    /// </summary>
+    /// <remarks>
+    /// A value above 1 is read as a legacy 0-100 percentage (<c>50</c> becomes
+    /// <c>0.5</c>), which is how this setting used to behave, so settings.json
+    /// files written before the change keep the background they had.
+    /// </remarks>
+    public double BackgroundOpacity { get; set; } = 0;
 
     public bool LimitSpeaking { get; set; } = false;
 
     public bool SmallAvatars { get; set; } = false;
 
     public bool HideNames { get; set; } = false;
+
+    /// <summary>
+    /// Pin your own profile to the top of the voice stack instead of sorting it
+    /// alphabetically with everyone else. StreamKit calls this "Show My Avatar
+    /// First".
+    /// </summary>
+    public bool StreamerAvatarFirst { get; set; } = false;
 }

--- a/src/DiscordOverlay.Core/Streaming/StreamKitUrlBuilder.cs
+++ b/src/DiscordOverlay.Core/Streaming/StreamKitUrlBuilder.cs
@@ -27,14 +27,28 @@ public sealed class StreamKitUrlBuilder(IOptionsMonitor<StreamKitOverlayOptions>
             $"text_outline_color={Uri.EscapeDataString(opts.TextOutlineColor)}",
             $"text_outline_size={opts.TextOutlineSize.ToString(CultureInfo.InvariantCulture)}",
             $"bg_color={Uri.EscapeDataString(opts.BackgroundColor)}",
-            $"bg_opacity={(opts.BackgroundOpacity / 100.0).ToString("0.##", CultureInfo.InvariantCulture)}",
+            $"bg_opacity={NormalizeOpacity(opts.BackgroundOpacity).ToString("0.##", CultureInfo.InvariantCulture)}",
             $"limit_speaking={LowerBool(opts.LimitSpeaking)}",
             $"small_avatars={LowerBool(opts.SmallAvatars)}",
             $"hide_names={LowerBool(opts.HideNames)}",
+            $"streamer_avatar_first={LowerBool(opts.StreamerAvatarFirst)}",
         };
 
         return $"{BaseUrl}/{channel.GuildId}/{channel.ChannelId}?{string.Join('&', query)}";
     }
 
     private static string LowerBool(bool value) => value ? "true" : "false";
+
+    /// <summary>
+    /// StreamKit reads <c>bg_opacity</c> as a 0-1 fraction, and so does the
+    /// setting, so the common case is a straight pass-through. Anything above 1
+    /// is a settings.json written when this was a 0-100 percentage; divide it
+    /// down rather than let an old config turn the background fully opaque.
+    /// </summary>
+    private static double NormalizeOpacity(double value)
+    {
+        if (double.IsNaN(value)) return 0;
+        if (value > 1) value /= 100.0;
+        return Math.Clamp(value, 0, 1);
+    }
 }

--- a/tests/DiscordOverlay.Core.Tests/Configuration/AppConfigStoreTests.cs
+++ b/tests/DiscordOverlay.Core.Tests/Configuration/AppConfigStoreTests.cs
@@ -1,0 +1,97 @@
+using DiscordOverlay.Core;
+
+namespace DiscordOverlay.Core.Tests.Configuration;
+
+public class AppConfigStoreTests : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "dovl-cfg-" + Guid.NewGuid().ToString("N"));
+
+    private string Path_ => Path.Combine(directory, "settings.json");
+
+    public AppConfigStoreTests() => Directory.CreateDirectory(directory);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(directory, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReturnsDefaults_WhenFileDoesNotExist()
+    {
+        var config = await AppConfigStore.LoadAsync(Path_);
+        Assert.Equal(0, config.Streamkit.BackgroundOpacity);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReadsDecimalOpacity()
+    {
+        await File.WriteAllTextAsync(Path_, """{ "Streamkit": { "BackgroundOpacity": 0.75 } }""");
+
+        var config = await AppConfigStore.LoadAsync(Path_);
+
+        Assert.Equal(0.75, config.Streamkit.BackgroundOpacity);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReadsQuotedNumbers()
+    {
+        // What you get from copying a value out of the README, or from an editor
+        // that quotes everything. It used to take the whole file down with it.
+        await File.WriteAllTextAsync(Path_, """{ "Streamkit": { "BackgroundOpacity": "0.75", "TextSize": "18" } }""");
+
+        var config = await AppConfigStore.LoadAsync(Path_);
+
+        Assert.Equal(0.75, config.Streamkit.BackgroundOpacity);
+        Assert.Equal(18, config.Streamkit.TextSize);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ToleratesCommentsAndTrailingCommas()
+    {
+        await File.WriteAllTextAsync(Path_, """
+            {
+              // hand-edited
+              "Streamkit": {
+                "StreamerAvatarFirst": true,
+              },
+            }
+            """);
+
+        var config = await AppConfigStore.LoadAsync(Path_);
+
+        Assert.True(config.Streamkit.StreamerAvatarFirst);
+    }
+
+    [Fact]
+    public async Task LoadAsync_KeepsACopy_WhenTheFileCannotBeParsed()
+    {
+        await File.WriteAllTextAsync(Path_, """{ "Obs": { "Port": ] }""");
+
+        var config = await AppConfigStore.LoadAsync(Path_);
+
+        // Defaults so the app still starts...
+        Assert.Equal(4455, config.Obs.Port);
+        // ...but not at the cost of what the user wrote, since the next save
+        // writes those defaults over settings.json.
+        var preserved = Path.Combine(directory, "settings.invalid.json");
+        Assert.True(File.Exists(preserved), "the unparseable settings file should be preserved");
+        Assert.Contains("\"Port\"", await File.ReadAllTextAsync(preserved));
+    }
+
+    [Fact]
+    public async Task SaveAsync_RoundTrips()
+    {
+        var config = new AppConfig();
+        config.Streamkit.BackgroundOpacity = 0.75;
+        config.Streamkit.StreamerAvatarFirst = true;
+        config.Obs.BrowserSourceName = "Overlay";
+
+        await AppConfigStore.SaveAsync(config, Path_);
+        var reloaded = await AppConfigStore.LoadAsync(Path_);
+
+        Assert.Equal(0.75, reloaded.Streamkit.BackgroundOpacity);
+        Assert.True(reloaded.Streamkit.StreamerAvatarFirst);
+        Assert.Equal("Overlay", reloaded.Obs.BrowserSourceName);
+    }
+}

--- a/tests/DiscordOverlay.Core.Tests/Streaming/StreamKitUrlBuilderTests.cs
+++ b/tests/DiscordOverlay.Core.Tests/Streaming/StreamKitUrlBuilderTests.cs
@@ -35,10 +35,11 @@ public class StreamKitUrlBuilderTests
         Assert.Contains("logo=white", url);
         Assert.Contains("text_color=%23ffffff", url);
         Assert.Contains("text_size=14", url);
-        Assert.Contains("bg_opacity=0", url);
+        Assert.Contains("bg_opacity=0&", url);
         Assert.Contains("limit_speaking=false", url);
         Assert.Contains("small_avatars=false", url);
         Assert.Contains("hide_names=false", url);
+        Assert.Contains("streamer_avatar_first=false", url);
     }
 
     [Fact]
@@ -49,9 +50,10 @@ public class StreamKitUrlBuilderTests
             ShowIcon = false,
             OnlineOnly = false,
             TextSize = 18,
-            BackgroundOpacity = 50,
+            BackgroundOpacity = 0.5,
             LimitSpeaking = true,
             HideNames = true,
+            StreamerAvatarFirst = true,
         });
         var info = new DiscordVoiceChannelInfo { ChannelId = "C", GuildId = "G" };
 
@@ -63,6 +65,26 @@ public class StreamKitUrlBuilderTests
         Assert.Contains("bg_opacity=0.5", url);
         Assert.Contains("limit_speaking=true", url);
         Assert.Contains("hide_names=true", url);
+        Assert.Contains("streamer_avatar_first=true", url);
+    }
+
+    [Theory]
+    // The scale users actually write, and the one StreamKit itself uses.
+    [InlineData(0, "0")]
+    [InlineData(0.75, "0.75")]
+    [InlineData(1, "1")]
+    // Above 1 is a settings.json from when this was a 0-100 percentage.
+    [InlineData(50, "0.5")]
+    [InlineData(95, "0.95")]
+    // Nonsense in either reading still has to produce a value StreamKit accepts.
+    [InlineData(150, "1")]
+    [InlineData(-3, "0")]
+    public void Build_TreatsBackgroundOpacityAsAFraction(double configured, string expected)
+    {
+        var sut = BuildSut(new StreamKitOverlayOptions { BackgroundOpacity = configured });
+        var info = new DiscordVoiceChannelInfo { ChannelId = "C", GuildId = "G" };
+
+        Assert.Contains($"bg_opacity={expected}&", sut.Build(info)!);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #27. Closes #28.

## #27 — `BackgroundOpacity` does nothing, or eats the config file

Two separate faults, one setting.

`BackgroundOpacity` was an `int` on a 0-100 scale, and nothing said so — not the
README, not the property name, and there is no UI for it, so the only way to
learn the scale was to guess. Setting it to `1`, the obvious way to ask for an
opaque background, produced `bg_opacity=0.01`. The option looked broken because
it looked like it did nothing.

Writing `0.75` instead threw at deserialisation. `AppConfigStore.LoadAsync`
catches `JsonException` and returns defaults, and the Settings form's save path
is load-then-write — so the next save put those defaults over the whole file.
One decimal point cost the user every other setting they had.

- `BackgroundOpacity` is now a `double` on StreamKit's own 0-1 scale, so what
  you write is what lands in `bg_opacity`. A value above 1 is read as the old
  percentage (`50` → `0.5`), so existing `settings.json` files keep the
  background they had.
- The file is documented as hand-editable, so it is now read like one: quoted
  numbers (`"0.75"`), `//` comments, trailing commas.
- An edit that does leave it unparseable is copied to `settings.invalid.json`
  before defaults can replace it. Falling back to defaults is fine; overwriting
  the user's file with them is not.

## #28 — no way to pin your own profile to the top

StreamKit has had this as "Show My Avatar First"; there was no equivalent here.
`StreamerAvatarFirst` maps to its `streamer_avatar_first` parameter, confirmed
against the live StreamKit bundle rather than guessed:

```js
{"label":"Show My Avatar First", checked: this.state.settings.streamer_avatar_first}
```

## Tests

Seven new cases: the opacity scale (fraction, legacy percentage, clamping), and
the settings file — decimals, quoted numbers, comments and trailing commas, the
preserved copy, and a save/load round-trip. 47 pass.

Both READMEs updated, including `TextOutlineColor` / `TextOutlineSize`, which
the documented schema had been missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoWzyBcG81DJgKKYfENQT