### PR TITLE
feat(settings): an Overlay appearance dialog, and the four settings we never sent

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -169,15 +169,16 @@ l'écrit ; vous pouvez l'éditer à la main si vous voulez). Schéma :
     "RefreshTimeout": "00:00:05"
   },
   "Streamkit": {
-    "ShowIcon": true,
-    "OnlineOnly": true,
-    "Logo": "white",
     "TextColor": "#ffffff",
     "TextSize": 14,
     "TextOutlineColor": "#000000",
     "TextOutlineSize": 0,
+    "TextShadowColor": "#000000",
+    "TextShadowSize": 0,
     "BackgroundColor": "#1e2124",
     "BackgroundOpacity": 0,
+    "BackgroundShadowColor": "#000000",
+    "BackgroundShadowSize": 0,
     "LimitSpeaking": false,
     "SmallAvatars": false,
     "HideNames": false,
@@ -194,22 +195,30 @@ prennent effet après un redémarrage de l'app, car la connexion WebSocket OBS
 n'est établie qu'une fois au démarrage. Les options de l'overlay StreamKit, elles,
 sont prises en compte à chaud.
 
-Deux options StreamKit méritent une précision :
+Le bloc `Streamkit` a sa propre fenêtre — **Paramètres**, puis **Apparence de
+l'overlay...** — avec un sélecteur pour chaque couleur et un envoi immédiat à
+OBS à l'enregistrement. Elle expose tous les réglages que lit le widget vocal
+StreamKit : rien ne vous oblige à passer par le fichier.
+
+Deux précisions pour qui édite quand même le fichier :
 
 - **`BackgroundOpacity`** est une fraction de `0` (transparent) à `1` (opaque)
   — l'échelle qu'utilise le `bg_opacity` de StreamKit lui-même. Les décimales
   s'écrivent avec un point : `0.75`. Une valeur supérieure à 1 est relue comme
   l'ancien pourcentage 0-100, pour qu'un `settings.json` écrit par une version
-  précédente garde le fond qu'il avait.
-- **`StreamerAvatarFirst`** épingle votre propre profil en haut de la pile
-  vocale au lieu de le trier alphabétiquement avec les autres. C'est le
-  « Show My Avatar First » de StreamKit.
+  précédente garde le fond qu'il avait. (La fenêtre l'affiche en pourcentage,
+  plus lisible à l'écran.)
+- **`ShowIcon`, `OnlineOnly` et `Logo` ont disparu.** Ils étaient envoyés en
+  `icon`, `online` et `logo`, qui appartiennent au widget *status* de
+  StreamKit ; le widget vocal ne les a jamais lus, c'étaient donc trois
+  réglages incapables d'avoir le moindre effet. Les laisser dans votre fichier
+  ne pose pas de problème : ils sont ignorés.
 
-Le fichier est prévu pour être édité à la main : les nombres entre guillemets
-(`"0.75"`), les commentaires `//` et les virgules finales sont acceptés. Si une
-édition le rend malgré tout illisible, l'application repart sur les valeurs par
-défaut et conserve votre version à côté sous le nom `settings.invalid.json`
-plutôt que de l'écraser.
+Le fichier reste éditable à la main : les nombres entre guillemets (`"0.75"`),
+les commentaires `//` et les virgules finales sont acceptés. Si une édition le
+rend malgré tout illisible, l'application repart sur les valeurs par défaut et
+conserve votre version à côté sous le nom `settings.invalid.json` plutôt que de
+l'écraser.
 
 ## Dépannage
 

--- a/README.md
+++ b/README.md
@@ -162,15 +162,16 @@ Schema:
     "RefreshTimeout": "00:00:05"
   },
   "Streamkit": {
-    "ShowIcon": true,
-    "OnlineOnly": true,
-    "Logo": "white",
     "TextColor": "#ffffff",
     "TextSize": 14,
     "TextOutlineColor": "#000000",
     "TextOutlineSize": 0,
+    "TextShadowColor": "#000000",
+    "TextShadowSize": 0,
     "BackgroundColor": "#1e2124",
     "BackgroundOpacity": 0,
+    "BackgroundShadowColor": "#000000",
+    "BackgroundShadowSize": 0,
     "LimitSpeaking": false,
     "SmallAvatars": false,
     "HideNames": false,
@@ -186,20 +187,27 @@ Host, port, password and Browser Source name changes take effect after an
 app restart since the OBS WebSocket connection is established once at
 startup. StreamKit overlay options pick up live.
 
-A few of the StreamKit options are worth spelling out:
+The `Streamkit` block has a dialog of its own — **Settings**, then **Overlay
+appearance...** — with a colour picker on each colour and a live push to OBS
+when you save. It carries every setting the StreamKit voice widget reads, so
+there is nothing you have to drop to the file for.
+
+Two notes for anyone editing the file directly:
 
 - **`BackgroundOpacity`** is a fraction from `0` (transparent) to `1` (opaque)
   — the scale StreamKit's own `bg_opacity` uses. Decimals use a dot: `0.75`.
   A value above 1 is read as the old 0-100 percentage, so a `settings.json`
-  written by an earlier version keeps the background it had.
-- **`StreamerAvatarFirst`** pins your own profile to the top of the voice
-  stack instead of sorting it in alphabetically. It is StreamKit's "Show My
-  Avatar First".
+  written by an earlier version keeps the background it had. (The dialog shows
+  it as a percentage, which is the friendlier form on screen.)
+- **`ShowIcon`, `OnlineOnly` and `Logo` are gone.** They were sent as `icon`,
+  `online` and `logo`, which belong to StreamKit's *status* widget; the voice
+  widget never read them, so they were three settings that could not do
+  anything. Leaving them in your file is harmless — they are ignored.
 
-The file is meant to be hand-editable, so quoted numbers (`"0.75"`), `//`
-comments and trailing commas are all accepted. If an edit does leave it
-unparseable, the app falls back to defaults and keeps your version as
-`settings.invalid.json` next to it rather than overwriting it.
+The file stays hand-editable, so quoted numbers (`"0.75"`), `//` comments and
+trailing commas are all accepted. If an edit does leave it unparseable, the app
+falls back to defaults and keeps your version as `settings.invalid.json` next
+to it rather than overwriting it.
 
 ## Troubleshooting
 

--- a/src/DiscordOverlay.App/Hosting/AppHostedService.cs
+++ b/src/DiscordOverlay.App/Hosting/AppHostedService.cs
@@ -13,6 +13,7 @@ public sealed class AppHostedService(
     IDiscordSession session,
     ObsConnectionTester obsTester,
     IOptionsMonitor<ObsConnectionOptions> obsOptions,
+    IOptionsMonitor<StreamKitOverlayOptions> overlayOptions,
     AutoStartManager autoStart,
     IUiDispatcher uiDispatcher,
     IHostApplicationLifetime lifetime,
@@ -66,7 +67,15 @@ public sealed class AppHostedService(
 
         var result = await uiDispatcher.InvokeAsync(() =>
         {
-            using var form = new SettingsForm(session, obsOptions.CurrentValue, autoStart, obsTester);
+            // No push callback here: OBS is not configured yet at first run, so
+            // an appearance change can only land in the file and be carried by
+            // the first push after setup.
+            using var form = new SettingsForm(
+                session,
+                obsOptions.CurrentValue,
+                autoStart,
+                obsTester,
+                () => overlayOptions.CurrentValue);
             return form.ShowDialog();
         }).ConfigureAwait(false);
 

--- a/src/DiscordOverlay.App/Hosting/TrayApplicationContext.cs
+++ b/src/DiscordOverlay.App/Hosting/TrayApplicationContext.cs
@@ -3,6 +3,7 @@ using DiscordOverlay.App.Settings;
 using DiscordOverlay.Core.Auth;
 using DiscordOverlay.Core.Discord;
 using DiscordOverlay.Core.Streaming;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -22,6 +23,8 @@ public sealed class TrayApplicationContext : ApplicationContext
     private readonly ObsConnectionTester obsTester;
     private readonly IDiscordSession session;
     private readonly IOptionsMonitor<ObsConnectionOptions> obsOptions;
+    private readonly IOptionsMonitor<StreamKitOverlayOptions> overlayOptions;
+    private readonly IConfiguration configuration;
     private readonly AutoStartManager autoStart;
     private readonly AppUpdater updater;
 
@@ -38,6 +41,8 @@ public sealed class TrayApplicationContext : ApplicationContext
         ObsConnectionTester obsTester,
         IDiscordSession session,
         IOptionsMonitor<ObsConnectionOptions> obsOptions,
+        IOptionsMonitor<StreamKitOverlayOptions> overlayOptions,
+        IConfiguration configuration,
         AutoStartManager autoStart,
         AppUpdater updater)
     {
@@ -48,6 +53,8 @@ public sealed class TrayApplicationContext : ApplicationContext
         this.obsTester = obsTester;
         this.session = session;
         this.obsOptions = obsOptions;
+        this.overlayOptions = overlayOptions;
+        this.configuration = configuration;
         this.autoStart = autoStart;
         this.updater = updater;
 
@@ -125,7 +132,13 @@ public sealed class TrayApplicationContext : ApplicationContext
 
     private void OnSettingsClicked(object? sender, EventArgs e)
     {
-        using var form = new SettingsForm(session, obsOptions.CurrentValue, autoStart, obsTester);
+        using var form = new SettingsForm(
+            session,
+            obsOptions.CurrentValue,
+            autoStart,
+            obsTester,
+            () => overlayOptions.CurrentValue,
+            RefreshOverlayAsync);
         var result = form.ShowDialog();
         if (result == DialogResult.Abort)
         {
@@ -133,6 +146,17 @@ public sealed class TrayApplicationContext : ApplicationContext
             logger.LogInformation("Sign-out from settings; exiting application");
             lifetime.StopApplication();
         }
+    }
+
+    /// <summary>
+    /// Pick up an appearance change and push it. The reload is not optional:
+    /// settings.json is watched, but that watch is asynchronous, so re-pushing
+    /// straight after a save would otherwise send the values it just replaced.
+    /// </summary>
+    private async Task RefreshOverlayAsync(CancellationToken cancellationToken)
+    {
+        (configuration as IConfigurationRoot)?.Reload();
+        await obsUpdater.RefreshAsync(cancellationToken).ConfigureAwait(true);
     }
 
     private void OnOpenLogFolderClicked(object? sender, EventArgs e)

--- a/src/DiscordOverlay.App/Resources/Strings.cs
+++ b/src/DiscordOverlay.App/Resources/Strings.cs
@@ -92,6 +92,38 @@ internal static class Strings
         ["SettingsSaveFailed"] = "Save failed: {0}",
         ["SettingsAutoStartFailed"] = "Settings saved, but auto-start could not be updated: {0}",
 
+        // Settings - overlay appearance
+        ["SettingsOverlayHeader"] = "Overlay appearance",
+        ["SettingsOverlayHint"] = "Colors, sizes and what the overlay shows. Applies to the Browser Source straight away.",
+        ["SettingsOverlayButton"] = "Overlay appearance...",
+
+        // Overlay appearance dialog
+        ["OverlayWindowTitle"] = "Discord-Overlay - Overlay appearance",
+        ["OverlayIntro"] = "These are the Discord StreamKit voice widget's own settings. Changes are pushed to your Browser Source as soon as you save.",
+        ["OverlayTextHeader"] = "Text",
+        ["OverlayBackgroundHeader"] = "Background",
+        ["OverlayDisplayHeader"] = "What to show",
+        ["OverlayTextColorLabel"] = "Color:",
+        ["OverlayTextSizeLabel"] = "Size:",
+        ["OverlayTextOutlineColorLabel"] = "Outline color:",
+        ["OverlayTextOutlineSizeLabel"] = "Outline size:",
+        ["OverlayTextShadowColorLabel"] = "Shadow color:",
+        ["OverlayTextShadowSizeLabel"] = "Shadow size:",
+        ["OverlayBackgroundColorLabel"] = "Color:",
+        ["OverlayBackgroundOpacityLabel"] = "Opacity:",
+        ["OverlayBackgroundShadowColorLabel"] = "Shadow color:",
+        ["OverlayBackgroundShadowSizeLabel"] = "Shadow size:",
+        ["OverlayLimitSpeakingCheckbox"] = "Only show people who are speaking",
+        ["OverlaySmallAvatarsCheckbox"] = "Small avatars",
+        ["OverlayHideNamesCheckbox"] = "Hide names",
+        ["OverlayStreamerAvatarFirstCheckbox"] = "Pin my own profile to the top",
+        ["OverlayZeroDisablesHint"] = "0 turns it off",
+        ["OverlayResetButton"] = "Reset to defaults",
+        ["OverlayPickColorTooltip"] = "Click to pick a color",
+        ["OverlaySaved"] = "Saved and pushed to OBS.",
+        ["OverlaySavedNotPushed"] = "Saved. It will reach OBS on the next channel change.",
+        ["OverlaySaveFailed"] = "Save failed: {0}",
+
         // Tray menu / status
         ["TrayInitialTooltip"] = "Discord-Overlay - starting",
         ["TrayChannelStarting"] = "Channel: starting",
@@ -202,6 +234,38 @@ internal static class Strings
         ["SettingsSaveFailed"] = "Échec de l'enregistrement : {0}",
         ["SettingsAutoStartFailed"] = "Paramètres enregistrés, mais le démarrage automatique n'a pas pu être mis à jour : {0}",
 
+        // Paramètres - apparence de l'overlay
+        ["SettingsOverlayHeader"] = "Apparence de l'overlay",
+        ["SettingsOverlayHint"] = "Couleurs, tailles et contenu affiché. S'applique immédiatement à la Browser Source.",
+        ["SettingsOverlayButton"] = "Apparence de l'overlay...",
+
+        // Fenêtre d'apparence de l'overlay
+        ["OverlayWindowTitle"] = "Discord-Overlay - Apparence de l'overlay",
+        ["OverlayIntro"] = "Ce sont les réglages du widget vocal Discord StreamKit lui-même. Les modifications sont envoyées à votre Browser Source dès l'enregistrement.",
+        ["OverlayTextHeader"] = "Texte",
+        ["OverlayBackgroundHeader"] = "Fond",
+        ["OverlayDisplayHeader"] = "Affichage",
+        ["OverlayTextColorLabel"] = "Couleur :",
+        ["OverlayTextSizeLabel"] = "Taille :",
+        ["OverlayTextOutlineColorLabel"] = "Couleur du contour :",
+        ["OverlayTextOutlineSizeLabel"] = "Épaisseur du contour :",
+        ["OverlayTextShadowColorLabel"] = "Couleur de l'ombre :",
+        ["OverlayTextShadowSizeLabel"] = "Taille de l'ombre :",
+        ["OverlayBackgroundColorLabel"] = "Couleur :",
+        ["OverlayBackgroundOpacityLabel"] = "Opacité :",
+        ["OverlayBackgroundShadowColorLabel"] = "Couleur de l'ombre :",
+        ["OverlayBackgroundShadowSizeLabel"] = "Taille de l'ombre :",
+        ["OverlayLimitSpeakingCheckbox"] = "N'afficher que les personnes qui parlent",
+        ["OverlaySmallAvatarsCheckbox"] = "Petits avatars",
+        ["OverlayHideNamesCheckbox"] = "Masquer les pseudos",
+        ["OverlayStreamerAvatarFirstCheckbox"] = "Épingler mon profil en haut",
+        ["OverlayZeroDisablesHint"] = "0 = désactivé",
+        ["OverlayResetButton"] = "Valeurs par défaut",
+        ["OverlayPickColorTooltip"] = "Cliquez pour choisir une couleur",
+        ["OverlaySaved"] = "Enregistré et envoyé à OBS.",
+        ["OverlaySavedNotPushed"] = "Enregistré. Sera appliqué au prochain changement de salon.",
+        ["OverlaySaveFailed"] = "Échec de l'enregistrement : {0}",
+
         // Barre d'état
         ["TrayInitialTooltip"] = "Discord-Overlay - démarrage",
         ["TrayChannelStarting"] = "Salon : démarrage",
@@ -305,6 +369,36 @@ internal static class Strings
     public static string SettingsSignOutFailed(string message) => Format(nameof(SettingsSignOutFailed), message);
     public static string SettingsSaveFailed(string message) => Format(nameof(SettingsSaveFailed), message);
     public static string SettingsAutoStartFailed(string message) => Format(nameof(SettingsAutoStartFailed), message);
+    public static string SettingsOverlayHeader => Get();
+    public static string SettingsOverlayHint => Get();
+    public static string SettingsOverlayButton => Get();
+
+    // Overlay appearance
+    public static string OverlayWindowTitle => Get();
+    public static string OverlayIntro => Get();
+    public static string OverlayTextHeader => Get();
+    public static string OverlayBackgroundHeader => Get();
+    public static string OverlayDisplayHeader => Get();
+    public static string OverlayTextColorLabel => Get();
+    public static string OverlayTextSizeLabel => Get();
+    public static string OverlayTextOutlineColorLabel => Get();
+    public static string OverlayTextOutlineSizeLabel => Get();
+    public static string OverlayTextShadowColorLabel => Get();
+    public static string OverlayTextShadowSizeLabel => Get();
+    public static string OverlayBackgroundColorLabel => Get();
+    public static string OverlayBackgroundOpacityLabel => Get();
+    public static string OverlayBackgroundShadowColorLabel => Get();
+    public static string OverlayBackgroundShadowSizeLabel => Get();
+    public static string OverlayLimitSpeakingCheckbox => Get();
+    public static string OverlaySmallAvatarsCheckbox => Get();
+    public static string OverlayHideNamesCheckbox => Get();
+    public static string OverlayStreamerAvatarFirstCheckbox => Get();
+    public static string OverlayZeroDisablesHint => Get();
+    public static string OverlayResetButton => Get();
+    public static string OverlayPickColorTooltip => Get();
+    public static string OverlaySaved => Get();
+    public static string OverlaySavedNotPushed => Get();
+    public static string OverlaySaveFailed(string message) => Format(nameof(OverlaySaveFailed), message);
 
     // Tray
     public static string TrayInitialTooltip => Get();

--- a/src/DiscordOverlay.App/Settings/ColorField.cs
+++ b/src/DiscordOverlay.App/Settings/ColorField.cs
@@ -1,0 +1,118 @@
+using System.ComponentModel;
+using DiscordOverlay.App.Resources;
+
+namespace DiscordOverlay.App.Settings;
+
+/// <summary>
+/// A colour swatch that opens the system colour picker, paired with the hex box
+/// people actually have on hand — StreamKit, OBS and every palette site speak
+/// hex, so typing one in has to work as well as clicking.
+/// </summary>
+internal sealed class ColorField : FlowLayoutPanel
+{
+    private readonly Button swatch;
+    private readonly TextBox hexBox;
+    private bool updating;
+
+    public ColorField(string initialHex)
+    {
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        FlowDirection = FlowDirection.LeftToRight;
+        Margin = new Padding(0, 2, 0, 2);
+        WrapContents = false;
+
+        swatch = new Button
+        {
+            Size = new Size(34, 23),
+            FlatStyle = FlatStyle.Flat,
+            Margin = new Padding(0, 0, 6, 0),
+            TabStop = false,
+        };
+        swatch.FlatAppearance.BorderColor = SystemColors.ControlDark;
+        swatch.Click += OnPickColor;
+
+        hexBox = new TextBox
+        {
+            Size = new Size(84, 23),
+            Margin = Padding.Empty,
+            MaxLength = 7,
+        };
+        hexBox.TextChanged += OnHexTyped;
+
+        var tip = new ToolTip();
+        tip.SetToolTip(swatch, Strings.OverlayPickColorTooltip);
+
+        Controls.Add(swatch);
+        Controls.Add(hexBox);
+
+        Value = initialHex;
+    }
+
+    /// <summary>The colour as <c>#rrggbb</c>. Setting an unparseable value falls back to black.</summary>
+    // Runtime state, not a design-time property: this control is built in code,
+    // never dropped on a designer surface.
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Browsable(false)]
+    public string Value
+    {
+        get => hexBox.Text;
+        set
+        {
+            updating = true;
+            hexBox.Text = Normalize(value);
+            updating = false;
+            swatch.BackColor = Parse(hexBox.Text);
+        }
+    }
+
+    private void OnPickColor(object? sender, EventArgs e)
+    {
+        using var dialog = new ColorDialog
+        {
+            Color = Parse(hexBox.Text),
+            FullOpen = true,
+            AnyColor = true,
+        };
+        if (dialog.ShowDialog(FindForm()) == DialogResult.OK)
+        {
+            Value = $"#{dialog.Color.R:x2}{dialog.Color.G:x2}{dialog.Color.B:x2}";
+        }
+    }
+
+    private void OnHexTyped(object? sender, EventArgs e)
+    {
+        // Half-typed input is normal — "#ff" on the way to "#ff00aa" — so the
+        // swatch just holds its last good colour rather than flashing black.
+        if (updating) return;
+        if (TryParse(hexBox.Text, out var color))
+        {
+            swatch.BackColor = color;
+        }
+    }
+
+    private static string Normalize(string? value)
+    {
+        var text = (value ?? string.Empty).Trim();
+        if (text.Length == 0) return "#000000";
+        return text[0] == '#' ? text : "#" + text;
+    }
+
+    private static Color Parse(string? value) =>
+        TryParse(value, out var color) ? color : Color.Black;
+
+    private static bool TryParse(string? value, out Color color)
+    {
+        color = Color.Black;
+        var text = (value ?? string.Empty).Trim().TrimStart('#');
+        if (text.Length != 6) return false;
+        if (!int.TryParse(text, System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out var rgb))
+        {
+            return false;
+        }
+
+        color = Color.FromArgb((rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff);
+        return true;
+    }
+}

--- a/src/DiscordOverlay.App/Settings/OverlayAppearanceForm.cs
+++ b/src/DiscordOverlay.App/Settings/OverlayAppearanceForm.cs
@@ -1,0 +1,381 @@
+using DiscordOverlay.App.Resources;
+using DiscordOverlay.Core;
+using DiscordOverlay.Core.Streaming;
+
+namespace DiscordOverlay.App.Settings;
+
+/// <summary>
+/// Every setting the StreamKit voice widget reads, as controls.
+///
+/// Its own dialog rather than a tab in <see cref="SettingsForm"/>: appearance is
+/// what you come back to and fiddle with, and that form auto-sizes around a
+/// Discord group that swaps between a tall and a short panel — a TabControl,
+/// which does not auto-size, would take that away.
+/// </summary>
+public sealed class OverlayAppearanceForm : Form
+{
+    private readonly Func<CancellationToken, Task>? pushToObs;
+
+    private readonly ColorField textColor;
+    private readonly NumericUpDown textSize;
+    private readonly ColorField textOutlineColor;
+    private readonly NumericUpDown textOutlineSize;
+    private readonly ColorField textShadowColor;
+    private readonly NumericUpDown textShadowSize;
+
+    private readonly ColorField backgroundColor;
+    private readonly NumericUpDown backgroundOpacity;
+    private readonly ColorField backgroundShadowColor;
+    private readonly NumericUpDown backgroundShadowSize;
+
+    private readonly CheckBox limitSpeaking;
+    private readonly CheckBox smallAvatars;
+    private readonly CheckBox hideNames;
+    private readonly CheckBox streamerAvatarFirst;
+
+    private readonly Label statusLabel;
+
+    /// <param name="current">Values to populate the form with.</param>
+    /// <param name="pushToObs">
+    /// Re-push the overlay URL once the file is written, so a colour change is
+    /// visible without waiting for the next voice-channel change. Null when
+    /// there is nothing to push to.
+    /// </param>
+    public OverlayAppearanceForm(StreamKitOverlayOptions current, Func<CancellationToken, Task>? pushToObs = null)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+        this.pushToObs = pushToObs;
+
+        Text = Strings.OverlayWindowTitle;
+        StartPosition = FormStartPosition.CenterParent;
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        Font = new Font("Segoe UI", 9f);
+        AutoScaleMode = AutoScaleMode.Font;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+
+        try
+        {
+            Icon = Icon.ExtractAssociatedIcon(Application.ExecutablePath);
+        }
+        catch
+        {
+            // fall back to default
+        }
+
+        textColor = new ColorField(current.TextColor);
+        textSize = Number(1, 200, current.TextSize);
+        textOutlineColor = new ColorField(current.TextOutlineColor);
+        textOutlineSize = Number(0, 20, current.TextOutlineSize);
+        textShadowColor = new ColorField(current.TextShadowColor);
+        textShadowSize = Number(0, 20, current.TextShadowSize);
+
+        backgroundColor = new ColorField(current.BackgroundColor);
+        // Percent in the UI, fraction in the file. A percentage is what people
+        // expect to type for an opacity; StreamKit's URL wants 0-1, and making
+        // that conversion the form's job rather than the user's is the whole
+        // point of having a form.
+        backgroundOpacity = Number(0, 100, (int)Math.Round(ClampFraction(current.BackgroundOpacity) * 100));
+        backgroundShadowColor = new ColorField(current.BackgroundShadowColor);
+        backgroundShadowSize = Number(0, 40, current.BackgroundShadowSize);
+
+        limitSpeaking = Check(Strings.OverlayLimitSpeakingCheckbox, current.LimitSpeaking);
+        smallAvatars = Check(Strings.OverlaySmallAvatarsCheckbox, current.SmallAvatars);
+        hideNames = Check(Strings.OverlayHideNamesCheckbox, current.HideNames);
+        streamerAvatarFirst = Check(Strings.OverlayStreamerAvatarFirstCheckbox, current.StreamerAvatarFirst);
+
+        var intro = new Label
+        {
+            Text = Strings.OverlayIntro,
+            AutoSize = false,
+            Size = new Size(430, 34),
+            ForeColor = SystemColors.GrayText,
+            Margin = new Padding(3, 0, 3, 8),
+        };
+
+        var textGroup = Group(Strings.OverlayTextHeader, Rows(
+            (Strings.OverlayTextColorLabel, textColor, null),
+            (Strings.OverlayTextSizeLabel, textSize, null),
+            (Strings.OverlayTextOutlineColorLabel, textOutlineColor, null),
+            (Strings.OverlayTextOutlineSizeLabel, textOutlineSize, Strings.OverlayZeroDisablesHint),
+            (Strings.OverlayTextShadowColorLabel, textShadowColor, null),
+            (Strings.OverlayTextShadowSizeLabel, textShadowSize, Strings.OverlayZeroDisablesHint)));
+
+        var backgroundGroup = Group(Strings.OverlayBackgroundHeader, Rows(
+            (Strings.OverlayBackgroundColorLabel, backgroundColor, null),
+            (Strings.OverlayBackgroundOpacityLabel, backgroundOpacity, "%"),
+            (Strings.OverlayBackgroundShadowColorLabel, backgroundShadowColor, null),
+            (Strings.OverlayBackgroundShadowSizeLabel, backgroundShadowSize, Strings.OverlayZeroDisablesHint)));
+
+        var displayBody = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            FlowDirection = FlowDirection.TopDown,
+            WrapContents = false,
+            Margin = Padding.Empty,
+        };
+        displayBody.Controls.AddRange(new Control[] { limitSpeaking, smallAvatars, hideNames, streamerAvatarFirst });
+        var displayGroup = Group(Strings.OverlayDisplayHeader, displayBody);
+
+        statusLabel = new Label
+        {
+            AutoSize = false,
+            Anchor = AnchorStyles.Left | AnchorStyles.Right,
+            Height = 22,
+            TextAlign = ContentAlignment.MiddleLeft,
+            Margin = new Padding(3, 6, 3, 0),
+            ForeColor = SystemColors.GrayText,
+        };
+
+        var resetButton = new Button
+        {
+            Text = Strings.OverlayResetButton,
+            AutoSize = true,
+            Padding = new Padding(8, 4, 8, 4),
+            Margin = new Padding(0, 8, 0, 0),
+            Anchor = AnchorStyles.Left,
+        };
+        resetButton.Click += (_, _) => Apply(new StreamKitOverlayOptions());
+
+        var saveButton = new Button
+        {
+            Text = Strings.SettingsSaveButton,
+            AutoSize = true,
+            Padding = new Padding(12, 4, 12, 4),
+        };
+        saveButton.Click += async (_, _) => await OnSaveAsync(saveButton).ConfigureAwait(true);
+
+        var cancelButton = new Button
+        {
+            Text = Strings.SettingsCancelButton,
+            AutoSize = true,
+            Padding = new Padding(12, 4, 12, 4),
+            DialogResult = DialogResult.Cancel,
+        };
+        AcceptButton = saveButton;
+        CancelButton = cancelButton;
+
+        var buttonRow = new FlowLayoutPanel
+        {
+            Anchor = AnchorStyles.Right,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            FlowDirection = FlowDirection.RightToLeft,
+            Margin = new Padding(0, 8, 0, 0),
+        };
+        buttonRow.Controls.Add(cancelButton);
+        buttonRow.Controls.Add(saveButton);
+
+        var footer = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            ColumnCount = 2,
+            RowCount = 1,
+            Margin = Padding.Empty,
+        };
+        footer.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        footer.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+        footer.Controls.Add(resetButton, 0, 0);
+        footer.Controls.Add(buttonRow, 1, 0);
+
+        var root = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            ColumnCount = 1,
+            RowCount = 6,
+            Padding = new Padding(12, 10, 12, 12),
+        };
+        root.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+        for (var row = 0; row < root.RowCount; row++)
+        {
+            root.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        }
+
+        root.Controls.Add(intro, 0, 0);
+        root.Controls.Add(textGroup, 0, 1);
+        root.Controls.Add(backgroundGroup, 0, 2);
+        root.Controls.Add(displayGroup, 0, 3);
+        root.Controls.Add(statusLabel, 0, 4);
+        root.Controls.Add(footer, 0, 5);
+
+        Controls.Add(root);
+    }
+
+    /// <summary>The values on screen, as the options object they will be saved as.</summary>
+    public StreamKitOverlayOptions Result => new()
+    {
+        TextColor = textColor.Value,
+        TextSize = (int)textSize.Value,
+        TextOutlineColor = textOutlineColor.Value,
+        TextOutlineSize = (int)textOutlineSize.Value,
+        TextShadowColor = textShadowColor.Value,
+        TextShadowSize = (int)textShadowSize.Value,
+        BackgroundColor = backgroundColor.Value,
+        BackgroundOpacity = (double)backgroundOpacity.Value / 100.0,
+        BackgroundShadowColor = backgroundShadowColor.Value,
+        BackgroundShadowSize = (int)backgroundShadowSize.Value,
+        LimitSpeaking = limitSpeaking.Checked,
+        SmallAvatars = smallAvatars.Checked,
+        HideNames = hideNames.Checked,
+        StreamerAvatarFirst = streamerAvatarFirst.Checked,
+    };
+
+    private void Apply(StreamKitOverlayOptions values)
+    {
+        textColor.Value = values.TextColor;
+        textSize.Value = Clamp(textSize, values.TextSize);
+        textOutlineColor.Value = values.TextOutlineColor;
+        textOutlineSize.Value = Clamp(textOutlineSize, values.TextOutlineSize);
+        textShadowColor.Value = values.TextShadowColor;
+        textShadowSize.Value = Clamp(textShadowSize, values.TextShadowSize);
+        backgroundColor.Value = values.BackgroundColor;
+        backgroundOpacity.Value = Clamp(backgroundOpacity, (int)Math.Round(ClampFraction(values.BackgroundOpacity) * 100));
+        backgroundShadowColor.Value = values.BackgroundShadowColor;
+        backgroundShadowSize.Value = Clamp(backgroundShadowSize, values.BackgroundShadowSize);
+        limitSpeaking.Checked = values.LimitSpeaking;
+        smallAvatars.Checked = values.SmallAvatars;
+        hideNames.Checked = values.HideNames;
+        streamerAvatarFirst.Checked = values.StreamerAvatarFirst;
+    }
+
+    private async Task OnSaveAsync(Button saveButton)
+    {
+        saveButton.Enabled = false;
+        try
+        {
+            // Load-then-write, so the OBS and watcher sections — and any key
+            // this form does not show — survive a save from here.
+            var config = await AppConfigStore.LoadAsync().ConfigureAwait(true);
+            config.Streamkit = Result;
+            await AppConfigStore.SaveAsync(config).ConfigureAwait(true);
+
+            var pushed = await TryPushAsync().ConfigureAwait(true);
+
+            statusLabel.ForeColor = pushed ? Color.SeaGreen : SystemColors.GrayText;
+            statusLabel.Text = pushed ? Strings.OverlaySaved : Strings.OverlaySavedNotPushed;
+
+            await Task.Delay(600).ConfigureAwait(true);
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+        catch (Exception ex)
+        {
+            statusLabel.ForeColor = Color.Firebrick;
+            statusLabel.Text = Strings.OverlaySaveFailed(ex.Message);
+            saveButton.Enabled = true;
+        }
+    }
+
+    private async Task<bool> TryPushAsync()
+    {
+        if (pushToObs is null) return false;
+        try
+        {
+            await pushToObs(CancellationToken.None).ConfigureAwait(true);
+            return true;
+        }
+        catch (Exception)
+        {
+            // OBS being unreachable is not a reason to lose the save. The file
+            // is already written and the next channel change will carry it.
+            return false;
+        }
+    }
+
+    private static double ClampFraction(double value)
+    {
+        if (double.IsNaN(value)) return 0;
+        // Same legacy 0-100 reading as the URL builder, so an old settings.json
+        // shows the opacity it is actually producing.
+        if (value > 1) value /= 100.0;
+        return Math.Clamp(value, 0, 1);
+    }
+
+    private static decimal Clamp(NumericUpDown box, int value) =>
+        Math.Clamp(value, box.Minimum, box.Maximum);
+
+    private static NumericUpDown Number(int min, int max, int value) => new()
+    {
+        Minimum = min,
+        Maximum = max,
+        Value = Math.Clamp(value, min, max),
+        Size = new Size(70, 23),
+        Margin = new Padding(0, 3, 0, 3),
+        TextAlign = HorizontalAlignment.Right,
+    };
+
+    private static CheckBox Check(string text, bool value) => new()
+    {
+        Text = text,
+        Checked = value,
+        AutoSize = true,
+        Margin = new Padding(3, 3, 3, 3),
+    };
+
+    private static GroupBox Group(string header, Control body)
+    {
+        var box = new GroupBox
+        {
+            Text = header,
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Padding = new Padding(10, 6, 10, 8),
+            Margin = new Padding(3, 3, 3, 6),
+        };
+        box.Controls.Add(body);
+        return box;
+    }
+
+    /// <summary>
+    /// Label / control / optional grey note, one row each, in a grid so the
+    /// controls line up down the column whatever the label lengths are — which
+    /// they are not, between English and French.
+    /// </summary>
+    private static TableLayoutPanel Rows(params (string Label, Control Control, string? Note)[] rows)
+    {
+        var grid = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            ColumnCount = 3,
+            RowCount = rows.Length,
+            Margin = Padding.Empty,
+        };
+        grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+
+        for (var i = 0; i < rows.Length; i++)
+        {
+            grid.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            grid.Controls.Add(new Label
+            {
+                Text = rows[i].Label,
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+                Margin = new Padding(0, 7, 8, 3),
+            }, 0, i);
+            grid.Controls.Add(rows[i].Control, 1, i);
+            grid.Controls.Add(new Label
+            {
+                Text = rows[i].Note ?? string.Empty,
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+                ForeColor = SystemColors.GrayText,
+                Margin = new Padding(8, 7, 0, 3),
+            }, 2, i);
+        }
+
+        return grid;
+    }
+}

--- a/src/DiscordOverlay.App/Settings/SettingsForm.cs
+++ b/src/DiscordOverlay.App/Settings/SettingsForm.cs
@@ -16,6 +16,8 @@ public sealed class SettingsForm : Form
     private readonly IDiscordSession session;
     private readonly AutoStartManager autoStart;
     private readonly ObsConnectionTester obsTester;
+    private readonly Func<StreamKitOverlayOptions> currentOverlay;
+    private readonly Func<CancellationToken, Task>? pushOverlayToObs;
 
     private readonly GroupBox discordGroup;
     private readonly Panel signedInPanel;
@@ -39,15 +41,27 @@ public sealed class SettingsForm : Form
     private readonly Button saveButton;
     private readonly Label statusLabel;
 
+    /// <param name="currentOverlay">
+    /// Read lazily rather than captured, so the appearance dialog opens on what
+    /// is in the file now — including a save made since this form opened.
+    /// </param>
+    /// <param name="pushOverlayToObs">
+    /// Reload configuration and re-push the overlay URL after an appearance
+    /// save. Null when there is nothing to push to, e.g. during first-run setup.
+    /// </param>
     public SettingsForm(
         IDiscordSession session,
         ObsConnectionOptions currentObs,
         AutoStartManager autoStart,
-        ObsConnectionTester obsTester)
+        ObsConnectionTester obsTester,
+        Func<StreamKitOverlayOptions>? currentOverlay = null,
+        Func<CancellationToken, Task>? pushOverlayToObs = null)
     {
         this.session = session;
         this.autoStart = autoStart;
         this.obsTester = obsTester;
+        this.currentOverlay = currentOverlay ?? (static () => new StreamKitOverlayOptions());
+        this.pushOverlayToObs = pushOverlayToObs;
 
         Text = Strings.SettingsWindowTitle;
         StartPosition = FormStartPosition.CenterScreen;
@@ -294,6 +308,30 @@ public sealed class SettingsForm : Form
             obsTestButton, obsStatus,
         });
 
+        var overlayGroup = new GroupBox
+        {
+            Text = Strings.SettingsOverlayHeader,
+            Dock = DockStyle.Fill,
+            Size = new Size(548, 84),
+        };
+        var overlayHint = new Label
+        {
+            AutoSize = false,
+            Size = new Size(528, 32),
+            Location = new Point(10, 18),
+            ForeColor = SystemColors.GrayText,
+            Text = Strings.SettingsOverlayHint,
+        };
+        var overlayButton = new Button
+        {
+            Text = Strings.SettingsOverlayButton,
+            Location = new Point(10, 50),
+            AutoSize = true,
+            Padding = new Padding(12, 4, 12, 4),
+        };
+        overlayButton.Click += (_, _) => OnOverlayAppearanceClicked();
+        overlayGroup.Controls.AddRange(new Control[] { overlayHint, overlayButton });
+
         var startupGroup = new GroupBox
         {
             Text = Strings.SettingsStartupHeader,
@@ -357,7 +395,7 @@ public sealed class SettingsForm : Form
             AutoSize = true,
             AutoSizeMode = AutoSizeMode.GrowAndShrink,
             ColumnCount = 1,
-            RowCount = 5,
+            RowCount = 6,
             Padding = new Padding(12, 8, 12, 12),
         };
         root.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
@@ -368,9 +406,10 @@ public sealed class SettingsForm : Form
 
         root.Controls.Add(discordGroup, 0, 0);
         root.Controls.Add(obsGroup, 0, 1);
-        root.Controls.Add(startupGroup, 0, 2);
-        root.Controls.Add(statusLabel, 0, 3);
-        root.Controls.Add(buttonRow, 0, 4);
+        root.Controls.Add(overlayGroup, 0, 2);
+        root.Controls.Add(startupGroup, 0, 3);
+        root.Controls.Add(statusLabel, 0, 4);
+        root.Controls.Add(buttonRow, 0, 5);
 
         Controls.Add(root);
 
@@ -400,6 +439,15 @@ public sealed class SettingsForm : Form
             // user clicks Save.
             hostBox.Enabled = portBox.Enabled = passwordBox.Enabled = sourceNameBox.Enabled = true;
         }
+    }
+
+    private void OnOverlayAppearanceClicked()
+    {
+        // Its own dialog, and its own save: appearance lands in settings.json
+        // the moment you click Save there, without waiting on this form's Save,
+        // which is gated on Discord being connected and also restarts the app.
+        using var form = new OverlayAppearanceForm(currentOverlay(), pushOverlayToObs);
+        form.ShowDialog(this);
     }
 
     private static void OpenInBrowser(string url)

--- a/src/DiscordOverlay.Core/Streaming/ObsBrowserSourceUpdater.cs
+++ b/src/DiscordOverlay.Core/Streaming/ObsBrowserSourceUpdater.cs
@@ -41,6 +41,17 @@ public sealed class ObsBrowserSourceUpdater : BackgroundService
 
     public ConnectionState ConnectionState => (ConnectionState)connectionStateRaw;
 
+    /// <summary>
+    /// Re-push the current channel's URL now.
+    ///
+    /// The overlay options are read fresh on every build, but nothing re-pushes
+    /// between voice-channel changes — so without this a saved appearance change
+    /// would sit unapplied until the user next moved rooms, which reads exactly
+    /// like the setting not working.
+    /// </summary>
+    public Task RefreshAsync(CancellationToken cancellationToken = default) =>
+        PushIfChannelKnownAsync(cancellationToken);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         watcher.Changed += OnVoiceChannelChanged;

--- a/src/DiscordOverlay.Core/Streaming/StreamKitOverlayOptions.cs
+++ b/src/DiscordOverlay.Core/Streaming/StreamKitOverlayOptions.cs
@@ -1,20 +1,26 @@
 namespace DiscordOverlay.Core.Streaming;
 
+/// <summary>
+/// The StreamKit voice widget's settings, one property per query parameter it
+/// actually reads. The widget's own defaults object is the reference; anything
+/// not in it (icon, online, logo — those belong to the <c>status</c> widget) is
+/// ignored no matter what we send, so it does not belong here.
+/// </summary>
 public sealed class StreamKitOverlayOptions
 {
-    public bool ShowIcon { get; set; } = true;
-
-    public bool OnlineOnly { get; set; } = true;
-
-    public string Logo { get; set; } = "white";
-
     public string TextColor { get; set; } = "#ffffff";
 
     public int TextSize { get; set; } = 14;
 
+    /// <summary>Outline drawn around the text, as CSS <c>-webkit-text-stroke</c>. 0 disables it.</summary>
     public string TextOutlineColor { get; set; } = "#000000";
 
     public int TextOutlineSize { get; set; } = 0;
+
+    /// <summary>Drop shadow behind the text, as CSS <c>text-shadow</c>. 0 disables it.</summary>
+    public string TextShadowColor { get; set; } = "#000000";
+
+    public int TextShadowSize { get; set; } = 0;
 
     public string BackgroundColor { get; set; } = "#1e2124";
 
@@ -31,6 +37,12 @@ public sealed class StreamKitOverlayOptions
     /// </remarks>
     public double BackgroundOpacity { get; set; } = 0;
 
+    /// <summary>Drop shadow behind each entry's box, as CSS <c>box-shadow</c>. 0 disables it.</summary>
+    public string BackgroundShadowColor { get; set; } = "#000000";
+
+    public int BackgroundShadowSize { get; set; } = 0;
+
+    /// <summary>Show only the people currently speaking.</summary>
     public bool LimitSpeaking { get; set; } = false;
 
     public bool SmallAvatars { get; set; } = false;

--- a/src/DiscordOverlay.Core/Streaming/StreamKitUrlBuilder.cs
+++ b/src/DiscordOverlay.Core/Streaming/StreamKitUrlBuilder.cs
@@ -17,17 +17,22 @@ public sealed class StreamKitUrlBuilder(IOptionsMonitor<StreamKitOverlayOptions>
         }
 
         var opts = options.CurrentValue;
+
+        // One entry per setting the voice widget reads, in the order its own
+        // defaults object lists them. Sending anything else is not harmless —
+        // it is a knob the user can turn that does nothing.
         var query = new List<string>
         {
-            $"icon={LowerBool(opts.ShowIcon)}",
-            $"online={LowerBool(opts.OnlineOnly)}",
-            $"logo={Uri.EscapeDataString(opts.Logo)}",
             $"text_color={Uri.EscapeDataString(opts.TextColor)}",
-            $"text_size={opts.TextSize.ToString(CultureInfo.InvariantCulture)}",
+            $"text_size={Int(opts.TextSize)}",
             $"text_outline_color={Uri.EscapeDataString(opts.TextOutlineColor)}",
-            $"text_outline_size={opts.TextOutlineSize.ToString(CultureInfo.InvariantCulture)}",
+            $"text_outline_size={Int(opts.TextOutlineSize)}",
+            $"text_shadow_color={Uri.EscapeDataString(opts.TextShadowColor)}",
+            $"text_shadow_size={Int(opts.TextShadowSize)}",
             $"bg_color={Uri.EscapeDataString(opts.BackgroundColor)}",
             $"bg_opacity={NormalizeOpacity(opts.BackgroundOpacity).ToString("0.##", CultureInfo.InvariantCulture)}",
+            $"bg_shadow_color={Uri.EscapeDataString(opts.BackgroundShadowColor)}",
+            $"bg_shadow_size={Int(opts.BackgroundShadowSize)}",
             $"limit_speaking={LowerBool(opts.LimitSpeaking)}",
             $"small_avatars={LowerBool(opts.SmallAvatars)}",
             $"hide_names={LowerBool(opts.HideNames)}",
@@ -38,6 +43,8 @@ public sealed class StreamKitUrlBuilder(IOptionsMonitor<StreamKitOverlayOptions>
     }
 
     private static string LowerBool(bool value) => value ? "true" : "false";
+
+    private static string Int(int value) => value.ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
     /// StreamKit reads <c>bg_opacity</c> as a 0-1 fraction, and so does the

--- a/tests/DiscordOverlay.Core.Tests/Streaming/StreamKitUrlBuilderTests.cs
+++ b/tests/DiscordOverlay.Core.Tests/Streaming/StreamKitUrlBuilderTests.cs
@@ -30,12 +30,14 @@ public class StreamKitUrlBuilderTests
         var url = sut.Build(info)!;
 
         Assert.StartsWith("https://streamkit.discord.com/overlay/voice/999888777/111222333?", url);
-        Assert.Contains("icon=true", url);
-        Assert.Contains("online=true", url);
-        Assert.Contains("logo=white", url);
         Assert.Contains("text_color=%23ffffff", url);
         Assert.Contains("text_size=14", url);
+        Assert.Contains("text_outline_size=0", url);
+        Assert.Contains("text_shadow_color=%23000000", url);
+        Assert.Contains("text_shadow_size=0", url);
         Assert.Contains("bg_opacity=0&", url);
+        Assert.Contains("bg_shadow_color=%23000000", url);
+        Assert.Contains("bg_shadow_size=0", url);
         Assert.Contains("limit_speaking=false", url);
         Assert.Contains("small_avatars=false", url);
         Assert.Contains("hide_names=false", url);
@@ -43,14 +45,41 @@ public class StreamKitUrlBuilderTests
     }
 
     [Fact]
+    public void Build_EmitsExactlyTheParametersTheVoiceWidgetReads()
+    {
+        // The voice widget's own settings object is the contract. icon, online
+        // and logo belong to the status widget and are ignored here — sending
+        // them is what made them look like settings that did not work.
+        var sut = BuildSut(new StreamKitOverlayOptions());
+        var info = new DiscordVoiceChannelInfo { ChannelId = "C", GuildId = "G" };
+
+        var query = sut.Build(info)!.Split('?')[1].Split('&')
+            .Select(pair => pair.Split('=')[0])
+            .ToArray();
+
+        Assert.Equal(
+            [
+                "text_color", "text_size",
+                "text_outline_color", "text_outline_size",
+                "text_shadow_color", "text_shadow_size",
+                "bg_color", "bg_opacity",
+                "bg_shadow_color", "bg_shadow_size",
+                "limit_speaking", "small_avatars", "hide_names", "streamer_avatar_first",
+            ],
+            query);
+    }
+
+    [Fact]
     public void Build_RespectsOptionOverrides()
     {
         var sut = BuildSut(new StreamKitOverlayOptions
         {
-            ShowIcon = false,
-            OnlineOnly = false,
             TextSize = 18,
+            TextShadowColor = "#ff0000",
+            TextShadowSize = 3,
             BackgroundOpacity = 0.5,
+            BackgroundShadowColor = "#00ff00",
+            BackgroundShadowSize = 6,
             LimitSpeaking = true,
             HideNames = true,
             StreamerAvatarFirst = true,
@@ -59,10 +88,12 @@ public class StreamKitUrlBuilderTests
 
         var url = sut.Build(info)!;
 
-        Assert.Contains("icon=false", url);
-        Assert.Contains("online=false", url);
         Assert.Contains("text_size=18", url);
+        Assert.Contains("text_shadow_color=%23ff0000", url);
+        Assert.Contains("text_shadow_size=3", url);
         Assert.Contains("bg_opacity=0.5", url);
+        Assert.Contains("bg_shadow_color=%2300ff00", url);
+        Assert.Contains("bg_shadow_size=6", url);
         Assert.Contains("limit_speaking=true", url);
         Assert.Contains("hide_names=true", url);
         Assert.Contains("streamer_avatar_first=true", url);


### PR DESCRIPTION
Stacked on #29 — the base retargets to `master` on its own once that merges.

**Settings → Overlay appearance...** — every setting the StreamKit voice widget
reads, colour picker on each colour, and a push to OBS on save so a change
shows up without changing voice channel first.

I took the widget's own defaults object as the reference for what belongs in
that dialog, and comparing against it turned up faults in both directions.

### Four settings we never sent

All applied by the widget as CSS on each entry:

| Parameter | Effect |
| --- | --- |
| `text_shadow_color` / `text_shadow_size` | `text-shadow` behind the names |
| `bg_shadow_color` / `bg_shadow_size` | `box-shadow` behind each entry |

### Three we sent that were never read

`icon`, `online` and `logo` belong to StreamKit's **status** widget. The voice
component destructures exactly `text_color`, `text_size`, `text_outline_*`,
`text_shadow_*`, `bg_color`, `bg_opacity`, `bg_shadow_*`, `small_avatars` and
`hide_names`, and `renderVoiceStates` adds `limit_speaking` and
`streamer_avatar_first`. Nothing else.

So `ShowIcon`, `OnlineOnly` and `Logo` were three documented settings that
could not do anything — #27's complaint again, from a different cause. They are
removed, and `Build_EmitsExactlyTheParametersTheVoiceWidgetReads` now pins the
emitted list against the widget's set, so drift in either direction fails a
test instead of shipping a knob that turns nothing.

Existing files keep working: unknown keys were already ignored on both the
`System.Text.Json` and configuration-binding paths.

### Decisions worth flagging

**Percent in the dialog, fraction in the file.** Each is idiomatic where it
appears, and doing the conversion in the form rather than in the user's head is
the point of having a form — it is exactly what went wrong when the file was
the only interface.

**Its own dialog, not a tab.** `SettingsForm` auto-sizes around a Discord group
that swaps a tall sign-in panel for a short summary, and the comment there says
so; `TabControl` does not auto-size and would have cost that. Appearance is
also the thing you reopen most, and it should not sit behind a Save gated on
Discord being connected that then restarts the app — so it saves itself.

**The push needs an explicit config reload.** `settings.json` is watched, but
asynchronously, so re-pushing straight after a save would send the values it
just replaced. `TrayApplicationContext.RefreshOverlayAsync` calls
`IConfigurationRoot.Reload()` first, which updates `IOptionsMonitor` through
the change token before `ObsBrowserSourceUpdater.RefreshAsync` rebuilds the URL.
OBS being unreachable downgrades the message rather than losing the save.

### Verified

Both forms rendered off-screen and inspected, in English and French — the two
sets of label lengths are what the label/control/note grid exists for. 41 tests
pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoWzyBcG81DJgKKYfENQT